### PR TITLE
Ödeme ekranında mahalle ve ilçelerin yüklenmeme problemi

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -481,10 +481,6 @@ class Checkout {
 				$current_city_plate_number_prefixed
 			);
 
-			if ( ! $districts ) {
-				continue;
-			}
-
 			// remove WooCommerce default district field on checkout.
 			unset( $fields[ $type ][ $city_field_name ] );
 


### PR DESCRIPTION
Ödeme ekranında, eğer sayfa yüklendiğinde il alanı boş geliyorsa, ilçe ve mahalleler yüklenemiyordu, bu sorun giderildi.

Closes #15 