### PR TITLE
T.C. Kimlik Zorunluysa ve Alan Boşsa Sipariş Oluşturabilme Sorunu İçin Çözüm

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -440,10 +440,12 @@ class Checkout {
 				( new PostMetaEncryption() )->health_check() &&
 				( new PostMetaEncryption() )->test_the_encryption_key()
 			) {
-				// Encrypt the T.C. Identity fields.
-				$data['billing_hez_TC_number'] = ( new PostMetaEncryption() )->encrypt(
-					$data['billing_hez_TC_number']
-				);
+				if ( $data['billing_hez_TC_number'] ) {
+					// Encrypt the T.C. Identity fields.
+					$data['billing_hez_TC_number'] = ( new PostMetaEncryption() )->encrypt(
+						$data['billing_hez_TC_number']
+					);
+				}
 			} else {
 				// do not save the T.C. identitiy fields.
 				$data['billing_hez_TC_number'] = '******';


### PR DESCRIPTION
Bu PR'da eğer TC kimlik alanı zorunluysa ve alan boş bırakılmışsa sipariş oluşturabilme sorunu çözüldü. Sorun şundan kaynaklanıyordu:
- TC kimlik alanı boş gelse bile şifrelendiği için, alan şifrelenmiş değerle doldurulmuş oluyordu ve Woocommerce alan dolu olduğu için hata vermiyordu.
- closes #18 