### PR TITLE
Added Checkout Field Editor compatibility for the shipping_company field

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -209,7 +209,10 @@ class Checkout {
 		$fields['billing']['billing_hez_tax_number']['priority'] = 13;
 		$fields['billing']['billing_hez_tax_office']['priority'] = 14;
 
-		$fields['shipping']['shipping_company']['priority']    = 0;
+		if ( isset( $fields['shipping']['shipping_company'] ) ) {
+			$fields['shipping']['shipping_company']['priority'] = 0;
+		}
+
 		$fields['shipping']['shipping_first_name']['priority'] = 1;
 		$fields['shipping']['shipping_last_name']['priority']  = 2;
 		$fields['shipping']['shipping_country']['priority']    = 5;


### PR DESCRIPTION
Bu PR'da, ThemeHigh'ın geliştirdiği Checkout Field Editor for WooCommerce eklentisiyle shipping_company field'ı gizlendiğinde, ödeme sayfasında gizlenmemesi sorunu çözüldü.
Aslında, sadece shipping_company field'ı için, Checkout Field Editor for WooCommerce eklentisiyle uyumsuzlukların tamamı giderilmiş oldu.

Eğer isterseniz Checkout Field Editor for WooCommerce eklentisiyle tam uyumluluk için bir çalışma yapılabilir.