### PR TITLE
"Farklı bir adrese gönderilsin mi?" kutucuğu ile ilgili sorunlar için çözüm

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -18,7 +18,7 @@ var wc_hezarfen_checkout = {
     },
     mbgb_plugin_active: typeof wc_hezarfen_mbgb_backend !== 'undefined',
     should_notify_neighborhood_changed: function (type) {
-        return this.mbgb_plugin_active && (wc_hezarfen_mbgb_backend.address_source === type || (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !wc_hezarfen_checkout.ship_to_different_checked()))
+        return this.mbgb_plugin_active && (wc_hezarfen_mbgb_backend.address_source === type || (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !this.ship_to_different_checked()))
     },
     ship_to_different_checked: function () {
         return jQuery('#ship-to-different-address input').is(':checked');

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -182,7 +182,7 @@ jQuery( function( $ ) {
     }
 
     function ship_to_different_on_change(checkbox) {
-        if (wc_hezarfen_mbgb_backend.address_source === 'shipping') {
+        if (wc_hezarfen_checkout.mbgb_plugin_active && wc_hezarfen_mbgb_backend.address_source === 'shipping') {
             let address_type = $(checkbox).is(':checked') ? 'shipping' : 'billing';
             let neighborhood_select = $(`#${address_type}_address_1`);
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -16,6 +16,9 @@ var wc_hezarfen_checkout = {
                 jQuery('body').trigger('update_checkout');
         });
     },
+    should_notify_neighborhood_changed: function (type) {
+        return wc_hezarfen_mbgb_backend.address_source === type || (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !wc_hezarfen_checkout.ship_to_different_checked())
+    },
     ship_to_different_checked: function () {
         return jQuery('#ship-to-different-address input').is(':checked');
     }
@@ -118,8 +121,7 @@ jQuery( function( $ ) {
                 return;
             }
 
-            if (wc_hezarfen_mbgb_backend.address_source === type ||
-                (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !wc_hezarfen_checkout.ship_to_different_checked())) {
+            if (wc_hezarfen_checkout.should_notify_neighborhood_changed(type)) {
                 let province_plate_number = $('#' + type + '_state').val();
                 let district = $('#' + type + '_city').val();
                 let neighborhood = $(this).val();

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -43,8 +43,6 @@ jQuery( function( $ ) {
     });
 
     $.each(["billing", "shipping"], function(index, type){
-        let checkout_fields_wrapper = $('.woocommerce-' + type + '-fields');
-
         $("#"+type+"_state").on("select2:select", function(e){
             $('#' + type + '_city').prop("disabled", true);
 
@@ -96,7 +94,7 @@ jQuery( function( $ ) {
 
             var data = {
                 'dataType': 'neighborhood',
-                'cityPlateNumber': checkout_fields_wrapper.find('#' + type + '_state').val(),
+                'cityPlateNumber': $('#' + type + '_state').val(),
                 'district': selected.id
             };
 
@@ -115,8 +113,8 @@ jQuery( function( $ ) {
         });
 
         $('#' + type + '_address_1').on("select2:select", function(e){
-            let province_plate_number = checkout_fields_wrapper.find('#' + type + '_state').val();
-            let district = checkout_fields_wrapper.find('#' + type + '_city').val();
+            let province_plate_number = $('#' + type + '_state').val();
+            let district = $('#' + type + '_city').val();
             let neighborhood = e.params.data.id;
 
             wc_hezarfen_checkout.notify_neighborhood_changed(province_plate_number, district, neighborhood, type);

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -19,11 +19,6 @@ var wc_hezarfen_checkout = {
 };
 
 jQuery( function( $ ) {
-    $.each(["billing", "shipping"], function(index, type){
-        $('#' + type + '_city').select2();
-        $('#' + type + '_address_1').select2({ language: "tr" });
-    });
-
     $('#hezarfen_invoice_type').select2({ language: "tr" });
 
     $('#hezarfen_invoice_type').change(function(){
@@ -43,6 +38,9 @@ jQuery( function( $ ) {
     });
 
     $.each(["billing", "shipping"], function(index, type){
+        $('#' + type + '_city').select2();
+        $('#' + type + '_address_1').select2({ language: "tr" });
+
         $("#"+type+"_state").on("select2:select", function(e){
             $('#' + type + '_city').prop("disabled", true);
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -137,7 +137,10 @@ jQuery( function( $ ) {
             let neighborhood_select = $(`#${address_type}_address_1`);
 
             if (neighborhood_select.val()) {
-                neighborhood_select.trigger('select2:select');
+                // set a small timeout to prevent conflict with the Woocommerce's "update_checkout" trigger.
+                setTimeout(() => {
+                    neighborhood_select.trigger('select2:select');
+                }, 300);
             }
 		}
 	});

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -122,7 +122,7 @@ jQuery( function( $ ) {
                 (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !wc_hezarfen_checkout.ship_to_different_checked())) {
                 let province_plate_number = $('#' + type + '_state').val();
                 let district = $('#' + type + '_city').val();
-                let neighborhood = e.params.data.id;
+                let neighborhood = $(this).val();
 
                 wc_hezarfen_checkout.notify_neighborhood_changed(province_plate_number, district, neighborhood, type);
             }

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -111,7 +111,7 @@ jQuery( function( $ ) {
         });
 
         $('#' + type + '_address_1').on("select2:select", function(e){
-            if (typeof wc_hezarfen_mbgb_backend === 'undefined') {
+            if (typeof wc_hezarfen_mbgb_backend === 'undefined' || wc_hezarfen_mbgb_backend.address_source !== type) {
                 return;
             }
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -128,4 +128,15 @@ jQuery( function( $ ) {
             }
         });
     });
+
+	$('form.checkout').on('change', '#ship-to-different-address input', function () {
+		if (wc_hezarfen_mbgb_backend.address_source === 'shipping') {
+			let address_type = $(this).is(':checked') ? 'shipping' : 'billing';
+            let neighborhood_select = $(`#${address_type}_address_1`);
+
+            if (neighborhood_select.val()) {
+                neighborhood_select.trigger('select2:select');
+            }
+		}
+	});
 } );

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -15,6 +15,9 @@ var wc_hezarfen_checkout = {
             if(args.update_checkout)
                 jQuery('body').trigger('update_checkout');
         });
+    },
+    ship_to_different_checked: function () {
+        return jQuery('#ship-to-different-address input').is(':checked');
     }
 };
 
@@ -111,15 +114,18 @@ jQuery( function( $ ) {
         });
 
         $('#' + type + '_address_1').on("select2:select", function(e){
-            if (typeof wc_hezarfen_mbgb_backend === 'undefined' || wc_hezarfen_mbgb_backend.address_source !== type) {
+            if (typeof wc_hezarfen_mbgb_backend === 'undefined') {
                 return;
             }
 
-            let province_plate_number = $('#' + type + '_state').val();
-            let district = $('#' + type + '_city').val();
-            let neighborhood = e.params.data.id;
+            if (wc_hezarfen_mbgb_backend.address_source === type ||
+                (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !wc_hezarfen_checkout.ship_to_different_checked())) {
+                let province_plate_number = $('#' + type + '_state').val();
+                let district = $('#' + type + '_city').val();
+                let neighborhood = e.params.data.id;
 
-            wc_hezarfen_checkout.notify_neighborhood_changed(province_plate_number, district, neighborhood, type);
+                wc_hezarfen_checkout.notify_neighborhood_changed(province_plate_number, district, neighborhood, type);
+            }
         });
     });
 } );

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -16,8 +16,9 @@ var wc_hezarfen_checkout = {
                 jQuery('body').trigger('update_checkout');
         });
     },
+    mbgb_plugin_active: typeof wc_hezarfen_mbgb_backend !== 'undefined',
     should_notify_neighborhood_changed: function (type) {
-        return wc_hezarfen_mbgb_backend.address_source === type || (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !wc_hezarfen_checkout.ship_to_different_checked())
+        return this.mbgb_plugin_active && (wc_hezarfen_mbgb_backend.address_source === type || (wc_hezarfen_mbgb_backend.address_source === 'shipping' && !wc_hezarfen_checkout.ship_to_different_checked()))
     },
     ship_to_different_checked: function () {
         return jQuery('#ship-to-different-address input').is(':checked');
@@ -172,10 +173,6 @@ jQuery( function( $ ) {
     }
 
     function neighborhood_on_change(neighborhood, type, checkout_fields_wrapper) {
-        if (typeof wc_hezarfen_mbgb_backend === 'undefined') {
-            return;
-        }
-
         if (wc_hezarfen_checkout.should_notify_neighborhood_changed(type)) {
             let province_plate_number = checkout_fields_wrapper.find('#' + type + '_state').val();
             let district = checkout_fields_wrapper.find('#' + type + '_city').val();

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,3 +1,23 @@
+var wc_hezarfen_checkout = {
+    notify_neighborhood_changed: function (province_plate_number, district, neighborhood, type) {
+        var data = {
+            'action':'wc_hezarfen_neighborhood_changed',
+            'security': wc_hezarfen_ajax_object.mahalleio_nonce,
+            'cityPlateNumber': province_plate_number,
+            'district': district,
+            'neighborhood': neighborhood,
+            'type': type
+        };
+
+        jQuery.post(wc_hezarfen_ajax_object.ajax_url, data, function(response){
+            var args = JSON.parse(response);
+
+            if(args.update_checkout)
+                jQuery('body').trigger('update_checkout');
+        });
+    }
+};
+
 jQuery(document).ready(function($){
     $.each(["billing", "shipping"], function(index, type){
         $('#' + type + '_city').select2();
@@ -97,24 +117,11 @@ jQuery( function( $ ) {
         });
 
         $('#' + type + '_address_1').on("select2:select", function(e){
-            // get selected data
-            var selected = e.params.data;
+            let province_plate_number = checkout_fields_wrapper.find('#' + type + '_state').val();
+            let district = checkout_fields_wrapper.find('#' + type + '_city').val();
+            let neighborhood = e.params.data.id;
 
-            var data = {
-                'action':'wc_hezarfen_neighborhood_changed',
-                'security': wc_hezarfen_ajax_object.mahalleio_nonce,
-                'cityPlateNumber': checkout_fields_wrapper.find('#' + type + '_state').val(),
-                'district': checkout_fields_wrapper.find('#' + type + '_city').val(),
-                'neighborhood': selected.id,
-                'type': type
-            };
-
-            jQuery.post(wc_hezarfen_ajax_object.ajax_url, data, function(response){
-                var args = JSON.parse(response);
-
-                if(args.update_checkout)
-                    jQuery('body').trigger('update_checkout');
-            });
+            wc_hezarfen_checkout.notify_neighborhood_changed(province_plate_number, district, neighborhood, type);
         });
     });
 } );

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -111,6 +111,10 @@ jQuery( function( $ ) {
         });
 
         $('#' + type + '_address_1').on("select2:select", function(e){
+            if (typeof wc_hezarfen_mbgb_backend === 'undefined') {
+                return;
+            }
+
             let province_plate_number = $('#' + type + '_state').val();
             let district = $('#' + type + '_city').val();
             let neighborhood = e.params.data.id;

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,5 +1,9 @@
 var wc_hezarfen_checkout = {
     notify_neighborhood_changed: function (province_plate_number, district, neighborhood, type) {
+        if (!province_plate_number || !district || !neighborhood) {
+            return;
+        }
+
         var data = {
             'action':'wc_hezarfen_neighborhood_changed',
             'security': wc_hezarfen_ajax_object.mahalleio_nonce,
@@ -186,12 +190,10 @@ jQuery( function( $ ) {
             let address_type = $(checkbox).is(':checked') ? 'shipping' : 'billing';
             let neighborhood_select = $(`#${address_type}_address_1`);
 
-            if (neighborhood_select.val()) {
-                // set a small timeout to prevent conflict with the Woocommerce's "update_checkout" trigger.
-                setTimeout(() => {
-                    neighborhood_select.trigger('select2:select');
-                }, 300);
-            }
+            // set a small timeout to prevent conflict with the Woocommerce's "update_checkout" trigger.
+            setTimeout(() => {
+                neighborhood_select.trigger('select2:select');
+            }, 300);
         }
     }
 

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -18,16 +18,14 @@ var wc_hezarfen_checkout = {
     }
 };
 
-jQuery(document).ready(function($){
+jQuery( function( $ ) {
     $.each(["billing", "shipping"], function(index, type){
         $('#' + type + '_city').select2();
         $('#' + type + '_address_1').select2({ language: "tr" });
     });
 
     $('#hezarfen_invoice_type').select2({ language: "tr" });
-});
 
-jQuery( function( $ ) {
     $('#hezarfen_invoice_type').change(function(){
         var invoice_type = $(this).val();
 


### PR DESCRIPTION
Bu PR'da şu issue çözüldü:
- closes #32 

Ayrıca şu geliştirmeler yapıldı:
- MBGB eklentisi yüklü değilse artık ajax ile **"neighborhood_changed"** bildirimi yapılmıyor. (MBGB eklentisi dışında **"neighborhood_changed"** bildirimini kullanan başka eklentiler varsa bu geliştirmeyi geri alabilirim)
- Eğer MBGB eklentisi ayarlarında örneğin "Fatura" adresi seçiliyse, teslimat adresindeki mahalle değiştiğinde ajax ile **"neighborhood_changed"** bildirimi artık yapılmıyor (gerek olmadığı için).