### PR TITLE
PHP Warning tetikleyen TC No alanıyla ilgili sorun giderildi

### DIFF
--- a/assets/admin/css/order-details.css
+++ b/assets/admin/css/order-details.css
@@ -1,1 +1,5 @@
 .hezarfen-hide-form-field {display:none !important;}
+
+.hezarfen-tc-num-field strong {
+	display: block;
+}

--- a/assets/admin/js/order-details.js
+++ b/assets/admin/js/order-details.js
@@ -1,4 +1,4 @@
-jQuery(document).ready(function($){
+jQuery(document).ready(function ($) {
 
   $('a.edit_address').on('click', function () {
     $('.hezarfen-tc-num-field').hide();
@@ -6,19 +6,19 @@ jQuery(document).ready(function($){
 
   update_field_showing_statuses($('.hezarfen_billing_invoice_type_field').val());
 
-  $('.hezarfen_billing_invoice_type_field').change(function(){
+  $('.hezarfen_billing_invoice_type_field').change(function () {
 
     var invoice_type = $(this).val();
     update_field_showing_statuses(invoice_type);
 
   });
 
-  function update_field_showing_statuses(invoice_type){
-    if( invoice_type == 'person' ){
+  function update_field_showing_statuses(invoice_type) {
+    if (invoice_type == 'person') {
       $('._billing_hez_TC_number_field').removeClass('hezarfen-hide-form-field');
       $('._billing_hez_tax_number_field').addClass('hezarfen-hide-form-field');
       $('._billing_hez_tax_office_field').addClass('hezarfen-hide-form-field');
-    }else if( invoice_type == 'company' ){
+    } else if (invoice_type == 'company') {
       $('._billing_hez_TC_number_field').addClass('hezarfen-hide-form-field');
       $('._billing_hez_tax_number_field').removeClass('hezarfen-hide-form-field');
       $('._billing_hez_tax_office_field').removeClass('hezarfen-hide-form-field');

--- a/assets/admin/js/order-details.js
+++ b/assets/admin/js/order-details.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($){
 
+  $('a.edit_address').on('click', function () {
+    $('.hezarfen-tc-num-field').hide();
+  });
+
   update_field_showing_statuses($('.hezarfen_billing_invoice_type_field').val());
 
   $('.hezarfen_billing_invoice_type_field').change(function(){


### PR DESCRIPTION
Bu PR'da; **"PHP Warning:  openssl_decrypt(): IV passed is only X bytes long"** şeklinde PHP hatası tetikleyen sorun giderildi. Sorun şuydu:

TC Kimlik no'yu deşifre edilmiş şekilde admin sipariş detayı ekranında göstermek için `woocommerce_admin_billing_fields` hook'u kullanılıyordu. Bu hook `WC_Meta_Box_Order_Data::init_address_fields()` methodunun içerisinde bulunuyor. Bu method hem admin sipariş detayı ekranına bilgileri basan `WC_Meta_Box_Order_Data::output()` methodunda hem de **Update** butonuna tıklayınca çalışan ve siparişte yapılan değişiklikleri kaydeden `WC_Meta_Box_Order_Data::save()` methodunda kullanılıyor. Bu sebeple, admin sipariş detayı ekranından **Update** butonuna tıklanınca (siparişte herhangi bir değişiklik yapılmasa dahi), TC No verisi veritabanına deşifre edilmiş şekilde kaydediliyordu. Sonrasında sayfa yenilenince, `PostMetaEncryption::decrypt()` methodu zaten deşifre edilmiş olan TC No'yu deşifre etmeye çalışıyordu ve bu PHP hatası geliyordu. Sorun PHP 8'e özel değil, genel bir sorun.

Bu PR'la oluşturduğum yapıda TC No alanı admin sipariş detayı ekranından düzenlenemiyor. Önceden düzenlenebiliyordu. Sanırım bu durum bir sorun oluşturmayacaktır, çünkü zaten önceden düzgün çalışmıyordu.

- closes #44 