### PR TITLE
"Encryption Key Confirmation" ayarının ID'si değiştirildi

### DIFF
--- a/includes/admin/settings/class-hezarfen-settings-hezarfen.php
+++ b/includes/admin/settings/class-hezarfen-settings-hezarfen.php
@@ -83,7 +83,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 							'You can update the checkout TAX fields. Note: T.C. number field requires encryption feature. If you do not activate the encryption feature, T.C. number field does not appear on the checkout.',
 							'hezarfen-for-woocommerce'
 						),
-						'id'    => 'hezarfen_checkout_tax_fields_options',
+						'id'    => 'hezarfen_checkout_tax_fields_title',
 					),
 
 					array(
@@ -118,7 +118,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 
 					array(
 						'type' => 'sectionend',
-						'id'   => 'hezarfen_checkout_tax_fields_options',
+						'id'   => 'hezarfen_checkout_tax_fields_section_end',
 					),
 				)
 			);
@@ -147,7 +147,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 							'If the T.C. Identity Field is active, an encryption key must be generated. The following encryption key generated will be lost upon saving the form. Please back up the generated encryption key to a secure area, then paste it anywhere in the wp-config.php file. In case of deletion of the hezarfen-encryption-key line from wp-config.php, retrospectively, the orders will be sent to T.C. no values will become unreadable.',
 							'hezarfen-for-woocommerce'
 						),
-						'id'    => 'hezarfen_checkout_tax_fields_options',
+						'id'    => 'hezarfen_checkout_encryption_fields_title',
 					),
 					array(
 						'title'   => __(
@@ -181,7 +181,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 					),
 					array(
 						'type' => 'sectionend',
-						'id'   => 'hezarfen_checkout_tax_fields_options',
+						'id'   => 'hezarfen_checkout_encryption_fields_section_end',
 					),
 				);
 			}

--- a/includes/admin/settings/class-hezarfen-settings-hezarfen.php
+++ b/includes/admin/settings/class-hezarfen-settings-hezarfen.php
@@ -175,7 +175,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 							'I backed up the key to a secure area and placed it in the wp-config file. In case the encryption key value is deleted from the wp-config.php file, all past orders will be transferred to T.C. I know I cannot access ID data.',
 							'hezarfen-for-woocommerce'
 						),
-						'id'      => 'hezarfen_checkout_show_TC_identity_field',
+						'id'      => 'hezarfen_checkout_encryption_key_confirmation',
 						'default' => 'no',
 						'std'     => 'yes',
 					),
@@ -329,7 +329,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 
 		if ( 'encryption' == $current_section ) {
 			if (
-				get_option( 'hezarfen_checkout_show_TC_identity_field', false ) ==
+				get_option( 'hezarfen_checkout_encryption_key_confirmation', false ) ==
 				'yes'
 			) {
 				update_option( 'hezarfen_encryption_key_generated', 'yes' );


### PR DESCRIPTION
Bu PR'da **"Encryption Key Confirmation"** ayarının ID'si değiştirilmiştir. Önceden, **"Show T.C. Identity Field on checkout page"** ayarıyla aynı ID'ye sahipti ve veritabanında birbiri üzerine kaydediliyordu. Biri değiştirilince diğeri de değişiyordu.
Ayrıca, **"Encryption Key Confirmation"** checkbox'ı işaretlenmese bile ayarlar kaydediliyordu, şu anda kaydedilmiyor.

Bu PR'da, pek önemli olmayan bazı ayar ID'leri de düzenlendi.

- closes #45 