### PR TITLE
Hesabım > Adres düzenleme sayfaları geliştirmeleri

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -8,10 +8,12 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v2
-        - name: Install dependencies
-          run: composer install --dev --prefer-dist --no-progress --no-suggest
-        - name: PHPCS check
-          uses: chekalsky/phpcs-action@v1
+
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
           with:
-            enable_warnings: true
-            phpcs_bin_path: './vendor/bin/phpcs'
+            php-version: '7.3'
+            tools: cs2pr
+
+        - name: Run PHPCS
+          run: vendor/bin/phpcs -q --report=checkstyle --ignore=*/mahalle/* | cs2pr

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,5 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Analyse
-        uses: actions-x/phpstan@v1
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+
+      - name: Run PHPSTAN
+        run: vendor/bin/phpstan --memory-limit=512M

--- a/assets/js/mahalle-helper.js
+++ b/assets/js/mahalle-helper.js
@@ -41,7 +41,7 @@ class hezarfen_mahalle_helper {
 		// empty district and neighborhood select boxes
 		thisHelper.get_city_field().empty();
 		thisHelper.get_nbrhood_field().empty();
-		if (this.page === 'edit-address') {
+		if (thisHelper.page === 'edit-address') {
 			thisHelper.get_city_field().trigger('change');
 			thisHelper.get_nbrhood_field().trigger('change');
 		}
@@ -73,7 +73,7 @@ class hezarfen_mahalle_helper {
 
 		// empty neighborhood select box
 		thisHelper.get_nbrhood_field().empty();
-		if (this.page === 'edit-address') {
+		if (thisHelper.page === 'edit-address') {
 			thisHelper.get_nbrhood_field().trigger('change');
 		}
 

--- a/includes/Autoload.php
+++ b/includes/Autoload.php
@@ -14,80 +14,14 @@ defined( 'ABSPATH' ) || exit();
  */
 class Autoload {
 	/**
-	 * Addons info
-	 * 
-	 * @var array
-	 */
-	private $addons;
-
-	/**
-	 * Notices related to addons.
-	 * 
-	 * @var array
-	 */
-	private $addon_notices;
-
-	/**
 	 * Constructor
 	 *
 	 * @return void
 	 */
 	public function __construct() {
-		$this->addons = array(
-			array(
-				'name'        => 'Mahalle Bazlı Gönderim Bedeli for Hezarfen',
-				'short_name'  => 'MBGB',
-				'version'     => function () {
-					return defined( 'WC_HEZARFEN_MBGB_VERSION' ) ? WC_HEZARFEN_MBGB_VERSION : null;
-				},
-				'min_version' => WC_HEZARFEN_MIN_MBGB_VERSION,
-				'activated'   => function () {
-					return defined( 'WC_HEZARFEN_MBGB_VERSION' );
-				},
-			),
-		);
-
 		$this->load_plugin_files();
 
 		$this->load_assets();
-
-		register_activation_hook(
-			WC_HEZARFEN_FILE,
-			array(
-				'Hezarfen_Install',
-				'install',
-			)
-		);
-
-		add_action(
-			'plugins_loaded',
-			array(
-				$this,
-				'check_addons_and_show_notices',
-			)
-		);
-
-		add_filter(
-			'woocommerce_get_settings_pages',
-			array(
-				$this,
-				'add_hezarfen_setting_page',
-			)
-		);
-	}
-
-	/**
-	 *
-	 * Load Hezarfen Settings Page
-	 *
-	 * @param array $settings the current WC setting page paths.
-	 * @return array
-	 */
-	public function add_hezarfen_setting_page( $settings ) {
-		$settings[] = include_once WC_HEZARFEN_UYGULAMA_YOLU .
-			'includes/admin/settings/class-hezarfen-settings-hezarfen.php';
-
-		return $settings;
 	}
 	
 	/**
@@ -197,6 +131,8 @@ class Autoload {
 	 * @return void
 	 */
 	public function load_plugin_files() {
+		require_once 'class-hezarfen-wc-helper.php';
+		require_once 'class-hezarfen.php';
 		require_once 'Data/Abstracts/Abstract_Encryption.php';
 		require_once 'Data/ServiceCredentialEncryption.php';
 		require_once 'Data/PostMetaEncryption.php';
@@ -205,48 +141,10 @@ class Autoload {
 		require_once 'Ajax.php';
 		require_once 'class-mahalle-local.php';
 		require_once 'Hezarfen_Install.php';
-		require_once 'class-hezarfen-wc-helper.php';
 		require_once 'class-compatibility.php';
 
 		if ( is_admin() ) {
 			require_once 'admin/order/OrderDetails.php';
-		}
-	}
-
-	/**
-	 * Checks addons and shows notices if necessary.
-	 * Defines constants to disable outdated addons.
-	 * 
-	 * @return void
-	 */
-	public function check_addons_and_show_notices() {
-		$this->addon_notices = Helper::check_addons( $this->addons );
-		if ( $this->addon_notices ) {
-			foreach ( $this->addon_notices as $notice ) {
-				define( 'WC_HEZARFEN_OUTDATED_ADDON_' . $notice['addon_short_name'], true );
-			}
-
-			add_action(
-				'admin_notices',
-				function () {
-					Helper::show_admin_notices( $this->addon_notices );
-				}
-			);
-		}
-
-		// Check Intense Türkiye İl İlçe Eklentisi For WooCommerce plugin.
-		if ( defined( 'INTENSE_IL_ILCE_PLUGIN_PATH' ) ) {
-			add_action(
-				'admin_notices',
-				function () {
-					$notice = array(
-						'message' => __( '<strong>Hezarfen for WooCommerce</strong> eklentisinin sağıklı çalışabilmesi için <strong>Intense Türkiye İl İlçe Eklentisi For WooCommerce</strong> eklentisini siliniz. <strong>Hezarfen</strong> eklentisi zaten bünyesinde İl, ilçe ve mahalle verilerini barındırmaktadır.', 'hezarfen-for-woocommerce' ),
-						'type'    => 'error',
-					);
-
-					Helper::show_admin_notices( array( $notice ), true );
-				}
-			);
 		}
 	}
 }

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -43,7 +43,7 @@ class Checkout {
 		}
 
 		if ( 'yes' === get_option( 'hezarfen_hide_checkout_postcode_fields', 'no' ) ) {
-			add_filter( 'woocommerce_checkout_fields', array( $this, 'hide_postcode_fields' ), 90 );
+			add_action( 'wp', array( $this, 'hide_postcode_fields' ) );
 		}
 
 		// TODO: review the logic, if it's possible; define all fields in a single function.
@@ -146,16 +146,14 @@ class Checkout {
 	}
 
 	/**
-	 * Hide Post Code Fields where in the checkout form.
+	 * Hides Post Code Fields in the checkout form.
 	 *
-	 * @param  array $fields current checkout fields.
-	 * @return array
+	 * @return void
 	 */
-	public function hide_postcode_fields( $fields ) {
-		unset( $fields['billing']['billing_postcode'] );
-		unset( $fields['shipping']['shipping_postcode'] );
-
-		return $fields;
+	public function hide_postcode_fields() {
+		if ( is_checkout() ) {
+			Helper::hide_postcode_field();
+		}
 	}
 
 	/**

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -151,7 +151,8 @@ class Checkout {
 	 * @return void
 	 */
 	public function hide_postcode_fields() {
-		if ( is_checkout() ) {
+		$wc_ajax = $_GET['wc-ajax'] ?? ''; // phpcs:ignore
+		if ( is_checkout() || ( defined( 'WC_DOING_AJAX' ) && 'checkout' === $wc_ajax ) ) {
 			Helper::hide_postcode_field();
 		}
 	}

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -42,16 +42,6 @@ class Checkout {
 
 		if ( $checkout_fields_auto_sort ) {
 			add_filter( 'woocommerce_checkout_fields', array( $this, 'auto_sort_checkout_fields' ), 999999, 1 );
-
-			add_filter(
-				'woocommerce_default_address_fields',
-				array(
-					$this,
-					'sort_address_fields',
-				),
-				100000,
-				1
-			);
 		}
 
 		if ( $hide_postcode_field ) {
@@ -91,14 +81,6 @@ class Checkout {
 		);
 
 		add_filter(
-			'woocommerce_get_country_locale',
-			array(
-				$this,
-				'modify_tr_locale',
-			)
-		);
-
-		add_filter(
 			'woocommerce_checkout_posted_data',
 			array(
 				$this,
@@ -126,21 +108,6 @@ class Checkout {
 	}
 
 	/**
-	 * Sort address fields forcelly.
-	 *
-	 * @param  array $fields current default address fields.
-	 * @return array
-	 */
-	public function sort_address_fields( $fields ) {
-		$fields['state']['priority']     = 6;
-		$fields['city']['priority']      = 7;
-		$fields['address_1']['priority'] = 8;
-		$fields['address_2']['priority'] = 9;
-
-		return $fields;
-	}
-
-	/**
 	 * Make address 2 fields required.
 	 *
 	 * @param  array $fields current default address fields.
@@ -150,27 +117,6 @@ class Checkout {
 		$fields['address_2']['required'] = true;
 
 		return $fields;
-	}
-
-	/**
-	 * Modifies TR country locale data.
-	 * 
-	 * @param array $locales Locale data of all countries.
-	 * 
-	 * @return array
-	 */
-	public function modify_tr_locale( $locales ) {
-		// TODO: bu method (add_filter() ile birlikte) ayrı bir class'a çekilse daha iyi olur. Çünkü sadece checkout'u ilgilendirmiyor, aynı zamanda Hesabım > Adres düzenleme sayfalarındaki fieldları ve başka şeyleri de ilgilendiriyor.
-		$locales['TR']['city'] = array(
-			'label' => __( 'Town / City', 'hezarfen-for-woocommerce' ),
-		);
-
-		$locales['TR']['address_1'] = array(
-			'label'       => __( 'Neighborhood', 'hezarfen-for-woocommerce' ),
-			'placeholder' => __( 'Select an option', 'hezarfen-for-woocommerce' ),
-		);
-
-		return $locales;
 	}
 
 	/**

--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -415,15 +415,8 @@ class Checkout {
 			$current_city_plate_number_prefixed = $woocommerce->customer->$get_city_function();
 			$current_district                   = $woocommerce->customer->$get_district_function();
 
-			$districts = $this->get_districts(
-				$current_city_plate_number_prefixed
-			);
-
 			// remove WooCommerce default district field on checkout.
 			unset( $fields[ $type ][ $city_field_name ] );
-
-			// update array for name => name format.
-			$districts = Helper::select2_option_format( $districts );
 
 			$fields[ $type ][ $city_field_name ] = array(
 				'type'         => 'select',
@@ -433,7 +426,7 @@ class Checkout {
 				'clear'        => true,
 				'autocomplete' => 'address-level2',
 				'priority'     => $fields[ $type ][ $type . '_state' ]['priority'] + 1,
-				'options'      => $districts,
+				'options'      => Helper::select2_option_format( Mahalle_Local::get_districts( $current_city_plate_number_prefixed ) ),
 			);
 
 			$fields[ $type ][ $neighborhood_field_name ] = array(
@@ -444,52 +437,11 @@ class Checkout {
 				'clear'        => true,
 				'autocomplete' => 'address-level3',
 				'priority'     => $fields[ $type ][ $type . '_state' ]['priority'] + 2,
-				'options'      => $this->get_neighborhood_options( $current_city_plate_number_prefixed, $current_district ),
+				'options'      => Helper::select2_option_format( Mahalle_Local::get_neighborhoods( $current_city_plate_number_prefixed, $current_district, false ) ),
 			);
 		}
 
 		return $fields;
-	}
-
-	/**
-	 * Get districts
-	 *
-	 * @param string $city_plate_with_prefix that begins with TR prefix such as TR18.
-	 *
-	 * @return array
-	 */
-	private function get_districts( $city_plate_with_prefix ) {
-		if ( ! $city_plate_with_prefix ) {
-			return array();
-		}
-
-		$districts = Mahalle_Local::get_districts( $city_plate_with_prefix );
-
-		return $districts;
-	}
-
-	/**
-	 * Returns neighborhood options.
-	 * 
-	 * @param string $city_plate_with_prefix that begins with TR prefix such as TR18.
-	 * @param string $district District.
-	 * 
-	 * @return array
-	 */
-	private function get_neighborhood_options( $city_plate_with_prefix, $district ) {
-		$neighborhood_options = array( '' => __( 'Select an option', 'hezarfen-for-woocommerce' ) );
-
-		if ( ! $city_plate_with_prefix || ! $district ) {
-			return $neighborhood_options;
-		}
-
-		$neighborhoods = Mahalle_Local::get_neighborhoods( $city_plate_with_prefix, $district );
-
-		foreach ( $neighborhoods as $neighborhood ) {
-			$neighborhood_options[ $neighborhood ] = $neighborhood;
-		}
-
-		return $neighborhood_options;
 	}
 }
 

--- a/includes/admin/settings/class-hezarfen-settings-hezarfen.php
+++ b/includes/admin/settings/class-hezarfen-settings-hezarfen.php
@@ -261,6 +261,16 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 					'default' => 'no',
 				),
 				array(
+					'title'   => __(
+						'Hide postcode fields in My Account > Address pages?',
+						'hezarfen-for-woocommerce'
+					),
+					'type'    => 'checkbox',
+					'desc'    => '',
+					'id'      => 'hezarfen_hide_my_account_postcode_fields',
+					'default' => 'no',
+				),
+				array(
 					'type' => 'sectionend',
 					'id'   => 'hezarfen_general_settings_section_end',
 				),

--- a/includes/admin/settings/class-hezarfen-settings-hezarfen.php
+++ b/includes/admin/settings/class-hezarfen-settings-hezarfen.php
@@ -98,7 +98,6 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 						),
 						'id'      => 'hezarfen_checkout_show_TC_identity_field',
 						'default' => 'no',
-						'std'     => 'yes',
 					),
 
 					array(
@@ -177,7 +176,6 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 						),
 						'id'      => 'hezarfen_checkout_encryption_key_confirmation',
 						'default' => 'no',
-						'std'     => 'yes',
 					),
 					array(
 						'type' => 'sectionend',
@@ -210,7 +208,6 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 					'desc'    => '',
 					'id'      => 'hezarfen_hide_checkout_postcode_fields',
 					'default' => 'no',
-					'std'     => 'yes',
 				),
 				array(
 					'title'   => esc_html__(
@@ -221,7 +218,6 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 					'desc'    => '',
 					'id'      => 'hezarfen_checkout_fields_auto_sort',
 					'default' => 'no',
-					'std'     => 'yes',
 				),
 				array(
 					'type' => 'sectionend',
@@ -253,7 +249,6 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 					'desc'    => '',
 					'id'      => 'hezarfen_show_hezarfen_checkout_tax_fields',
 					'default' => 'no',
-					'std'     => 'yes',
 				),
 				array(
 					'type' => 'sectionend',

--- a/includes/admin/settings/class-hezarfen-settings-hezarfen.php
+++ b/includes/admin/settings/class-hezarfen-settings-hezarfen.php
@@ -251,6 +251,16 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 					'default' => 'no',
 				),
 				array(
+					'title'   => __(
+						'Sort address fields in My Account > Address pages?',
+						'hezarfen-for-woocommerce'
+					),
+					'type'    => 'checkbox',
+					'desc'    => '',
+					'id'      => 'hezarfen_sort_my_account_fields',
+					'default' => 'no',
+				),
+				array(
 					'type' => 'sectionend',
 					'id'   => 'hezarfen_general_settings_section_end',
 				),

--- a/includes/class-compatibility.php
+++ b/includes/class-compatibility.php
@@ -23,6 +23,8 @@ class Compatibility {
 		if ( 'Cartzilla' === $active_theme->name || 'Cartzilla' === $active_theme->parent_theme ) {
 			$this->cartzilla_support();
 		}
+
+		add_action( 'wp', array( $this, 'wp_action' ) );
 	}
 
 	/**
@@ -41,6 +43,29 @@ class Compatibility {
 		add_filter( 'hezarfen_checkout_fields_input_class_billing_hez_company', array( $this, 'add_bootstrap_form_control_class' ) );
 		add_filter( 'hezarfen_checkout_fields_input_class_billing_hez_tax_number', array( $this, 'add_bootstrap_form_control_class' ) );
 		add_filter( 'hezarfen_checkout_fields_input_class_billing_hez_tax_office', array( $this, 'add_bootstrap_form_control_class' ) );
+	}
+
+	/**
+	 * Adds Checkout Field Editor for WooCommerce plugin support.
+	 * 
+	 * @return void
+	 */
+	public function checkout_field_editor_support() {
+		add_filter( 'thwcfd_address_field_override_priority', '__return_false' );
+		add_filter( 'thwcfd_address_field_override_label', '__return_false' );
+		add_filter( 'thwcfd_address_field_override_placeholder', '__return_false' );
+		add_filter( 'thwcfd_address_field_override_class', '__return_false' );
+	}
+
+	/**
+	 * Runs when 'wp' action triggered.
+	 * 
+	 * @return void
+	 */
+	public function wp_action() {
+		if ( defined( 'THWCFD_VERSION' ) && 'yes' === get_option( 'hezarfen_sort_my_account_fields', 'no' ) && Helper::is_edit_address_page() ) {
+			$this->checkout_field_editor_support();
+		}
 	}
 
 	/**

--- a/includes/class-hezarfen-wc-helper.php
+++ b/includes/class-hezarfen-wc-helper.php
@@ -76,7 +76,10 @@ class Helper {
 			array( 'priority' => 80 )
 		);
 
-		$locales['TR']['postcode']['priority'] = 90;
+		$locales['TR']['postcode'] = array_merge(
+			$locales['TR']['postcode'] ?? array(),
+			array( 'priority' => 90 )
+		);
 
 		return $locales;
 	}
@@ -95,10 +98,15 @@ class Helper {
 			$type = isset( $address_fields['billing_country'] ) ? 'billing' : 'shipping';
 
 			if ( 'billing' === $type ) {
-				$address_fields['billing_phone']['priority'] = 32;
+				if ( isset( $address_fields['billing_phone'] ) ) {
+					$address_fields['billing_phone']['priority'] = 32;
+				}
+
 				$address_fields['billing_email']['priority'] = 34;
 			} elseif ( isset( $address_fields['shipping_company'] ) ) {
-				$address_fields['shipping_company']['priority'] = 5;
+				if ( isset( $address_fields['shipping_company'] ) ) {
+					$address_fields['shipping_company']['priority'] = 5;
+				}
 			}
 		}
 
@@ -114,8 +122,10 @@ class Helper {
 		add_filter(
 			'woocommerce_get_country_locale',
 			function ( $locales ) {
-				$locales['TR']['postcode']['required'] = false;
-				$locales['TR']['postcode']['hidden']   = true;
+				if ( isset( $locales['TR']['postcode'] ) ) {
+					$locales['TR']['postcode']['required'] = false;
+					$locales['TR']['postcode']['hidden']   = true;
+				}
 	
 				return $locales;
 			},

--- a/includes/class-hezarfen-wc-helper.php
+++ b/includes/class-hezarfen-wc-helper.php
@@ -47,6 +47,55 @@ class Helper {
 	}
 
 	/**
+	 * Hooks into the necessary filters to sort address fields.
+	 * 
+	 * @return void
+	 */
+	public static function sort_address_fields() {
+		add_filter( 'woocommerce_get_country_locale', array( __CLASS__, 'assign_priorities_to_address_fields' ), PHP_INT_MAX - 1 );
+		add_filter( 'woocommerce_billing_fields', array( __CLASS__, 'assign_priorities_to_phone_and_email' ), PHP_INT_MAX - 1, 2 );
+	}
+
+	/**
+	 * Assigns priorities to the address fields.
+	 * 
+	 * @param array<string, array<string, array<string, mixed>>> $locales Locale data of all countries.
+	 * 
+	 * @return array<string, array<string, array<string, mixed>>>
+	 */
+	public static function assign_priorities_to_address_fields( $locales ) {
+		$locales['TR']['state']['priority']     = 50;
+		$locales['TR']['city']['priority']      = 60;
+		$locales['TR']['address_1']['priority'] = 70;
+
+		$locales['TR']['address_2'] = array_merge(
+			$locales['TR']['address_2'] ?? array(),
+			array( 'priority' => 80 )
+		);
+
+		$locales['TR']['postcode']['priority'] = 90;
+
+		return $locales;
+	}
+
+	/**
+	 * Assigns priorities to the phone and email fields.
+	 * 
+	 * @param array<string, array<string, mixed>> $address_fields Address fields.
+	 * @param string                              $country Country.
+	 * 
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function assign_priorities_to_phone_and_email( $address_fields, $country ) {
+		if ( 'TR' === $country ) {
+			$address_fields['billing_phone']['priority'] = 32;
+			$address_fields['billing_email']['priority'] = 34;
+		}
+
+		return $address_fields;
+	}
+
+	/**
 	 * Is My Account > Edit Address page? (billing or shipping address).
 	 * 
 	 * @return bool

--- a/includes/class-hezarfen-wc-helper.php
+++ b/includes/class-hezarfen-wc-helper.php
@@ -47,6 +47,16 @@ class Helper {
 	}
 
 	/**
+	 * Is My Account > Edit Address page? (billing or shipping address).
+	 * 
+	 * @return bool
+	 */
+	public static function is_edit_address_page() {
+		global $wp;
+		return is_account_page() && ! empty( $wp->query_vars['edit-address'] );
+	}
+
+	/**
 	 * Checks installed Hezarfen addons' versions. Returns notices if there are outdated addons.
 	 * 
 	 * @param array $addons Addons data to check.

--- a/includes/class-hezarfen-wc-helper.php
+++ b/includes/class-hezarfen-wc-helper.php
@@ -106,6 +106,24 @@ class Helper {
 	}
 
 	/**
+	 * Hides the postcode field.
+	 * 
+	 * @return void
+	 */
+	public static function hide_postcode_field() {
+		add_filter(
+			'woocommerce_get_country_locale',
+			function ( $locales ) {
+				$locales['TR']['postcode']['required'] = false;
+				$locales['TR']['postcode']['hidden']   = true;
+	
+				return $locales;
+			},
+			PHP_INT_MAX - 1 
+		);
+	}
+
+	/**
 	 * Is My Account > Edit Address page? (billing or shipping address).
 	 * 
 	 * @return bool

--- a/includes/class-hezarfen-wc-helper.php
+++ b/includes/class-hezarfen-wc-helper.php
@@ -104,9 +104,7 @@ class Helper {
 
 				$address_fields['billing_email']['priority'] = 34;
 			} elseif ( isset( $address_fields['shipping_company'] ) ) {
-				if ( isset( $address_fields['shipping_company'] ) ) {
-					$address_fields['shipping_company']['priority'] = 5;
-				}
+				$address_fields['shipping_company']['priority'] = 5;
 			}
 		}
 

--- a/includes/class-hezarfen.php
+++ b/includes/class-hezarfen.php
@@ -45,10 +45,10 @@ class Hezarfen {
 			),
 		);
 
+		register_activation_hook( WC_HEZARFEN_FILE, array( 'Hezarfen_Install', 'install' ) );
+
 		add_action( 'plugins_loaded', array( $this, 'check_addons_and_show_notices' ) );
 		add_filter( 'woocommerce_get_settings_pages', array( $this, 'add_hezarfen_setting_page' ) );
-
-		register_activation_hook( WC_HEZARFEN_FILE, array( 'Hezarfen_Install', 'install' ) );
 	}
 
 	/**

--- a/includes/class-hezarfen.php
+++ b/includes/class-hezarfen.php
@@ -50,10 +50,6 @@ class Hezarfen {
 		add_action( 'plugins_loaded', array( $this, 'check_addons_and_show_notices' ) );
 		add_filter( 'woocommerce_get_settings_pages', array( $this, 'add_hezarfen_setting_page' ) );
 		add_filter( 'woocommerce_get_country_locale', array( $this, 'modify_tr_locale' ), PHP_INT_MAX - 2 );
-
-		if ( 'yes' === get_option( 'hezarfen_checkout_fields_auto_sort', 'no' ) ) {
-			add_filter( 'woocommerce_default_address_fields', array( $this, 'sort_address_fields' ), 100000, 1 );
-		}
 	}
 
 	/**
@@ -80,21 +76,6 @@ class Hezarfen {
 		);
 
 		return $locales;
-	}
-
-	/**
-	 * Sort address fields forcelly
-	 *
-	 * @param  array $fields current default address fields.
-	 * @return array
-	 */
-	public function sort_address_fields( $fields ) {
-		$fields['state']['priority']     = 6;
-		$fields['city']['priority']      = 7;
-		$fields['address_1']['priority'] = 8;
-		$fields['address_2']['priority'] = 9;
-
-		return $fields;
 	}
 
 	/**

--- a/includes/class-hezarfen.php
+++ b/includes/class-hezarfen.php
@@ -45,29 +45,10 @@ class Hezarfen {
 			),
 		);
 
-		add_action(
-			'plugins_loaded',
-			array(
-				$this,
-				'check_addons_and_show_notices',
-			)
-		);
+		add_action( 'plugins_loaded', array( $this, 'check_addons_and_show_notices' ) );
+		add_filter( 'woocommerce_get_settings_pages', array( $this, 'add_hezarfen_setting_page' ) );
 
-		add_filter(
-			'woocommerce_get_settings_pages',
-			array(
-				$this,
-				'add_hezarfen_setting_page',
-			)
-		);
-
-		register_activation_hook(
-			WC_HEZARFEN_FILE,
-			array(
-				'Hezarfen_Install',
-				'install',
-			)
-		);
+		register_activation_hook( WC_HEZARFEN_FILE, array( 'Hezarfen_Install', 'install' ) );
 	}
 
 	/**

--- a/includes/class-hezarfen.php
+++ b/includes/class-hezarfen.php
@@ -49,6 +49,46 @@ class Hezarfen {
 
 		add_action( 'plugins_loaded', array( $this, 'check_addons_and_show_notices' ) );
 		add_filter( 'woocommerce_get_settings_pages', array( $this, 'add_hezarfen_setting_page' ) );
+		add_filter( 'woocommerce_get_country_locale', array( $this, 'modify_tr_locale' ) );
+
+		if ( 'yes' === get_option( 'hezarfen_checkout_fields_auto_sort', 'no' ) ) {
+			add_filter( 'woocommerce_default_address_fields', array( $this, 'sort_address_fields' ), 100000, 1 );
+		}
+	}
+
+	/**
+	 * Modifies TR country locale data.
+	 * 
+	 * @param array $locales Locale data of all countries.
+	 * 
+	 * @return array
+	 */
+	public function modify_tr_locale( $locales ) {
+		$locales['TR']['city'] = array(
+			'label' => __( 'Town / City', 'hezarfen-for-woocommerce' ),
+		);
+
+		$locales['TR']['address_1'] = array(
+			'label'       => __( 'Neighborhood', 'hezarfen-for-woocommerce' ),
+			'placeholder' => __( 'Select an option', 'hezarfen-for-woocommerce' ),
+		);
+
+		return $locales;
+	}
+
+	/**
+	 * Sort address fields forcelly
+	 *
+	 * @param  array $fields current default address fields.
+	 * @return array
+	 */
+	public function sort_address_fields( $fields ) {
+		$fields['state']['priority']     = 6;
+		$fields['city']['priority']      = 7;
+		$fields['address_1']['priority'] = 8;
+		$fields['address_2']['priority'] = 9;
+
+		return $fields;
 	}
 
 	/**

--- a/includes/class-hezarfen.php
+++ b/includes/class-hezarfen.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Contains the Hezarfen main class.
+ * 
+ * @package Hezarfen\Inc
+ */
+
+namespace Hezarfen\Inc;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Hezarfen main class.
+ */
+class Hezarfen {
+	/**
+	 * Addons info
+	 * 
+	 * @var array
+	 */
+	private $addons;
+
+	/**
+	 * Notices related to addons.
+	 * 
+	 * @var array
+	 */
+	private $addon_notices;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->addons = array(
+			array(
+				'name'        => 'Mahalle Bazlı Gönderim Bedeli for Hezarfen',
+				'short_name'  => 'MBGB',
+				'version'     => function () {
+					return defined( 'WC_HEZARFEN_MBGB_VERSION' ) ? WC_HEZARFEN_MBGB_VERSION : null;
+				},
+				'min_version' => WC_HEZARFEN_MIN_MBGB_VERSION,
+				'activated'   => function () {
+					return defined( 'WC_HEZARFEN_MBGB_VERSION' );
+				},
+			),
+		);
+
+		add_action(
+			'plugins_loaded',
+			array(
+				$this,
+				'check_addons_and_show_notices',
+			)
+		);
+
+		add_filter(
+			'woocommerce_get_settings_pages',
+			array(
+				$this,
+				'add_hezarfen_setting_page',
+			)
+		);
+
+		register_activation_hook(
+			WC_HEZARFEN_FILE,
+			array(
+				'Hezarfen_Install',
+				'install',
+			)
+		);
+	}
+
+	/**
+	 * Checks addons and shows notices if necessary.
+	 * Defines constants to disable outdated addons.
+	 * 
+	 * @return void
+	 */
+	public function check_addons_and_show_notices() {
+		$this->addon_notices = Helper::check_addons( $this->addons );
+		if ( $this->addon_notices ) {
+			foreach ( $this->addon_notices as $notice ) {
+				define( 'WC_HEZARFEN_OUTDATED_ADDON_' . $notice['addon_short_name'], true );
+			}
+
+			add_action(
+				'admin_notices',
+				function () {
+					Helper::show_admin_notices( $this->addon_notices );
+				}
+			);
+		}
+
+		// Check Intense Türkiye İl İlçe Eklentisi For WooCommerce plugin.
+		if ( defined( 'INTENSE_IL_ILCE_PLUGIN_PATH' ) ) {
+			add_action(
+				'admin_notices',
+				function () {
+					$notice = array(
+						'message' => __( '<strong>Hezarfen for WooCommerce</strong> eklentisinin sağıklı çalışabilmesi için <strong>Intense Türkiye İl İlçe Eklentisi For WooCommerce</strong> eklentisini siliniz. <strong>Hezarfen</strong> eklentisi zaten bünyesinde İl, ilçe ve mahalle verilerini barındırmaktadır.', 'hezarfen-for-woocommerce' ),
+						'type'    => 'error',
+					);
+
+					Helper::show_admin_notices( array( $notice ), true );
+				}
+			);
+		}
+	}
+
+	/**
+	 *
+	 * Load Hezarfen Settings Page
+	 *
+	 * @param array $settings the current WC setting page paths.
+	 * @return array
+	 */
+	public function add_hezarfen_setting_page( $settings ) {
+		$settings[] = include_once WC_HEZARFEN_UYGULAMA_YOLU .
+			'includes/admin/settings/class-hezarfen-settings-hezarfen.php';
+
+		return $settings;
+	}
+}
+
+new Hezarfen();

--- a/includes/class-hezarfen.php
+++ b/includes/class-hezarfen.php
@@ -49,7 +49,7 @@ class Hezarfen {
 
 		add_action( 'plugins_loaded', array( $this, 'check_addons_and_show_notices' ) );
 		add_filter( 'woocommerce_get_settings_pages', array( $this, 'add_hezarfen_setting_page' ) );
-		add_filter( 'woocommerce_get_country_locale', array( $this, 'modify_tr_locale' ) );
+		add_filter( 'woocommerce_get_country_locale', array( $this, 'modify_tr_locale' ), PHP_INT_MAX - 2 );
 
 		if ( 'yes' === get_option( 'hezarfen_checkout_fields_auto_sort', 'no' ) ) {
 			add_filter( 'woocommerce_default_address_fields', array( $this, 'sort_address_fields' ), 100000, 1 );
@@ -64,13 +64,19 @@ class Hezarfen {
 	 * @return array
 	 */
 	public function modify_tr_locale( $locales ) {
-		$locales['TR']['city'] = array(
-			'label' => __( 'Town / City', 'hezarfen-for-woocommerce' ),
+		$locales['TR']['city'] = array_merge(
+			$locales['TR']['city'] ?? array(),
+			array(
+				'label' => __( 'Town / City', 'hezarfen-for-woocommerce' ),
+			)
 		);
 
-		$locales['TR']['address_1'] = array(
-			'label'       => __( 'Neighborhood', 'hezarfen-for-woocommerce' ),
-			'placeholder' => __( 'Select an option', 'hezarfen-for-woocommerce' ),
+		$locales['TR']['address_1'] = array_merge(
+			$locales['TR']['address_1'] ?? array(),
+			array(
+				'label'       => __( 'Neighborhood', 'hezarfen-for-woocommerce' ),
+				'placeholder' => __( 'Select an option', 'hezarfen-for-woocommerce' ),
+			)
 		);
 
 		return $locales;

--- a/includes/class-my-account.php
+++ b/includes/class-my-account.php
@@ -50,6 +50,11 @@ class My_Account {
 		return $address;
 	}
 
+	/**
+	 * Sorts the address fields.
+	 * 
+	 * @return void
+	 */
 	public function sort_address_fields() {
 		if ( Helper::is_edit_address_page() ) {
 			Helper::sort_address_fields();

--- a/includes/class-my-account.php
+++ b/includes/class-my-account.php
@@ -24,6 +24,10 @@ class My_Account {
 			// we need to use an action that fires after the 'posts_selection' action to access the is_account_page() function. (https://woocommerce.com/document/conditional-tags/).
 			add_action( 'wp', array( $this, 'sort_address_fields' ) );
 		}
+
+		if ( 'yes' === get_option( 'hezarfen_hide_my_account_postcode_fields', 'no' ) ) {
+			add_action( 'wp', array( $this, 'hide_postcode_field' ) );
+		}
 	}
 
 	/**
@@ -58,6 +62,17 @@ class My_Account {
 	public function sort_address_fields() {
 		if ( Helper::is_edit_address_page() ) {
 			Helper::sort_address_fields();
+		}
+	}
+
+	/**
+	 * Hides the postcode field.
+	 * 
+	 * @return void
+	 */
+	public function hide_postcode_field() {
+		if ( Helper::is_edit_address_page() ) {
+			Helper::hide_postcode_field();
 		}
 	}
 

--- a/includes/class-my-account.php
+++ b/includes/class-my-account.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains the class that adds district and neighborhood select elements to the My Account edit address pages.
+ * Contains the class that adds features related to the My Account edit address pages.
  * 
  * @package Hezarfen\Inc
  */
@@ -10,7 +10,7 @@ namespace Hezarfen\Inc;
 defined( 'ABSPATH' ) || exit();
 
 /**
- * Adds district and neighborhood select elements to the My Account edit address pages.
+ * Adds features related to the My Account edit address pages.
  */
 class My_Account {
 	/**
@@ -19,6 +19,11 @@ class My_Account {
 	public function __construct() {
 		add_filter( 'woocommerce_address_to_edit', array( $this, 'convert_to_select_elements' ), PHP_INT_MAX - 1, 2 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+		if ( 'yes' === get_option( 'hezarfen_sort_my_account_fields', 'no' ) ) {
+			// we need to use an action that fires after the 'posts_selection' action to access the is_account_page() function. (https://woocommerce.com/document/conditional-tags/).
+			add_action( 'wp', array( $this, 'sort_address_fields' ) );
+		}
 	}
 
 	/**
@@ -43,6 +48,12 @@ class My_Account {
 		$address[ $nbrhood_key ]['options']  = Helper::select2_option_format( Mahalle_Local::get_neighborhoods( $customer_province_code, $customer_district, false ) );
 
 		return $address;
+	}
+
+	public function sort_address_fields() {
+		if ( Helper::is_edit_address_page() ) {
+			Helper::sort_address_fields();
+		}
 	}
 
 	/**

--- a/includes/class-my-account.php
+++ b/includes/class-my-account.php
@@ -51,9 +51,7 @@ class My_Account {
 	 * @return void
 	 */
 	public function enqueue_scripts() {
-		global $wp;
-
-		if ( is_account_page() && ! empty( $wp->query_vars['edit-address'] ) ) {
+		if ( Helper::is_edit_address_page() ) {
 			wp_enqueue_script( 'wc_hezarfen_my_account_addresses_js', plugins_url( 'assets/js/my-account-addresses.js', WC_HEZARFEN_FILE ), array( 'jquery', 'wc_hezarfen_mahalle_helper_js' ), WC_HEZARFEN_VERSION, true );
 		}
 	}

--- a/includes/class-my-account.php
+++ b/includes/class-my-account.php
@@ -18,6 +18,7 @@ class My_Account {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_address_to_edit', array( $this, 'convert_to_select_elements' ), PHP_INT_MAX - 1, 2 );
+		add_action( 'woocommerce_after_save_address_validation', array( $this, 'save_customer_object' ), PHP_INT_MAX - 1, 4 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		if ( 'yes' === get_option( 'hezarfen_sort_my_account_fields', 'no' ) ) {
@@ -52,6 +53,20 @@ class My_Account {
 		$address[ $nbrhood_key ]['options']  = Helper::select2_option_format( Mahalle_Local::get_neighborhoods( $customer_province_code, $customer_district, false ) );
 
 		return $address;
+	}
+
+	/**
+	 * Saves the customer object to prevent problems if there are errors when saving address.
+	 *
+	 * @param int         $user_id User ID being saved.
+	 * @param string      $load_address Type of address e.g. billing or shipping.
+	 * @param array       $address The address fields.
+	 * @param WC_Customer $customer The customer object being saved.
+	 */
+	public function save_customer_object( $user_id, $load_address, $address, $customer ) {
+		if ( wc_notice_count( 'error' ) > 0 ) {
+			$customer->save();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Bu PR'da şu geliştirmeler yapılmıştır:
- Hesabım > Adres düzenleme sayfaları için field sıralama ve posta kodu gizleme özelliği eklendi. Bu iki özellik için ayarlar sayfasına iki tane ayar eklendi. Bu ayarlar için ayrı bir section açmadım, **General** sectionunun içerisine koydum, isterseniz açabilirim. Veya bence daha güzeli, **Checkout Page Settings** ve **Checkout Tax Fields** sectionlarını da **General** sectionunun içerisine almak. Böylece kullanıcılar ayarlara daha rahat erişebilir. Zaten o sectionların içerisinde çok az ayar var.
- Ödeme sayfası kodlarını da içeren çeşitli refactoring işlemleri yapıldı.
- Bu PR üzerinde çalışırken farkettiğim çeşitli buglar giderildi (buglar için issue'lar açtım.)

closes #52 
closes #59
closes #60
closes #63 
closes #64
