### PR TITLE
Release v2.10.1

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -17,13 +17,14 @@ Bu komut **her zaman** plugin kök dizininde çalışır:
 - `cd` ile plugin dizinine git, `git status` ile temiz mi kontrol et. Kirli ise dur ve kullanıcıya bildir.
 - `git fetch --tags --prune origin` çalıştır (master, develop, tag'ler güncel olsun).
 - Mevcut branch `develop` olmalı; değilse `git checkout develop` ile geç (veya kullanıcıya sor).
-- `git pull --ff-only origin develop` ile lokal develop'ı güncelle. Fast-forward değilse dur ve kullanıcıya bildir.
-- `origin/master`'ın da güncel olduğundan emin ol (fetch sonrası zaten öyle olmalı). Karşılaştırma `origin/master..develop` üzerinden yapılır.
+- `git pull --ff-only origin develop` ile lokal develop'ı güncelle. Fast-forward değilse dur.
+- **Develop master'la sync mi kontrol et.** `git log develop..origin/master --oneline` çıktı veriyorsa develop master'ın gerisinde (önceki release PR'ı merge commit ile geldi). Önce `git merge --ff-only origin/master` ile FF et, başarılı olursa `git push origin develop`. FF mümkün değilse dur ve kullanıcıya sor.
 
-### 2. Yayınlanmamış commit'leri topla
-- `develop` üzerinde olup `master`'da olmayan commit'ler: `git log origin/master..develop --pretty=format:'%h %s' --no-merges`
-- Sanity check için son semver tag: `git tag --sort=-v:refname | head -1` — bu tag normalde `master`'ın tepesinde olmalı; değilse kullanıcıya uyarı ver ama devam et.
-- Eğer hiç yeni commit yoksa: "release atılacak değişiklik yok" deyip dur.
+### 2. Son tag'i bul ve yayınlanmamış commit'leri topla
+- En son semver tag: `LATEST_TAG=$(git tag --sort=-v:refname | head -1)`
+- Bu tag'den `develop`'a kadarki yayınlanmamış commit'ler: `git log "$LATEST_TAG"..develop --pretty=format:'%h %s' --no-merges`
+  - Bu liste hem master'a düşmüş ama henüz tag'lenmemiş commit'leri (önceki release'den sonra merge edilen tooling/hotfix gibi şeyler) hem de develop'ta master'a girmemiş commit'leri kapsar — develop az önce master'la FF'lendiği için ikisi de aynı bakış açısından görünür.
+- Eğer hiç commit yoksa: "release atılacak değişiklik yok" deyip dur.
 
 ### 3. Versiyon bump kararı
 - `$ARGUMENTS` `major` içeriyorsa → major bump (X+1.0.0).

--- a/hezarfen-for-woocommerce.php
+++ b/hezarfen-for-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Kargo Takip, Kargo SMS, İlçe Mahalle Sözleşme by Hezarfen
  * Description: WooCommerce kargo takip ve kargo entegrasyon eklentisi. 26+ kargo firması: kargo barkod oluşturma, kargo durum sorgulama, kargo SMS ve e-posta bildirimleri. Ücretsiz Hepsijet kargo entegrasyonu. İlçe/mahalle seçimi, mesafeli satış sözleşmesi, ön bilgilendirme formu, e-fatura alanları.
- * Version: 2.10.0
+ * Version: 2.10.1
  * Author: Intense Yazılım Ltd.
  * Author URI: https://intense.com.tr
  * Developer: Intense Yazılım Ltd.
@@ -27,7 +27,7 @@ if ( ! in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins',
 	return;
 }
 
-define( 'WC_HEZARFEN_VERSION', '2.10.0' );
+define( 'WC_HEZARFEN_VERSION', '2.10.1' );
 define( 'WC_HEZARFEN_MIN_MBGB_VERSION', '0.6.1' );
 define( 'WC_HEZARFEN_MIN_WC_VERSION', '6.9.0' );
 define( 'WC_HEZARFEN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 5.3
 Tested up to: 6.9
 Requires PHP: 7.0
 License: GPL2
-Stable tag: 2.10.0
+Stable tag: 2.10.1
 
 🚀 2 bin site! Kargo takip, ücretsiz Hepsijet Entegrasyonu (1-4 desi: 89,24TL+KDV - Hezarfen Pro gerekmez), Mesafeli Sözleşmeler, NetGSM sipariş SMS
 == Description ==
@@ -264,6 +264,9 @@ HepsiJET, Yurtiçi Kargo, Sürat Kargo, Aras Kargo, PTT Kargo, Trendyol Express,
 15. Hesabım sayfasında siparişe ait oluşmuş sözleşmelerin gösterilmesi
 
 == Changelog ==
+= 2.10.1 - 2026-04-20 =
+* Eklenti paketinden gereksiz geliştirici dosyaları kaldırıldı.
+
 = 2.10.0 - 2026-04-20 =
 * Fatura bilgileri sipariş e-postalarında, teşekkür sayfasında ve hesabım sipariş detayında gösterilmeye başlandı.
 


### PR DESCRIPTION
## Özet
Versiyon 2.10.1 release PR'ı (develop → master). 2.10.0'da yanlışlıkla pakete dahil edilen geliştirici dosyalarının (`.claude/`) WP.org dağıtımına sızmasını gideren hotfix.

## Changelog
* Eklenti paketinden gereksiz geliştirici dosyaları kaldırıldı.

## Bump türü
patch

---
Merge edildiğinde `auto-tag-release.yml` workflow'u tag, GitHub Release ve WordPress.org deploy'unu tek seferde yapar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)