### PR TITLE
test: e2e — kalan akışlar (MSS, country switch, ship-to-different, BACS, options, shipment tracking)

### DIFF
--- a/tests/e2e/admin-shipment-tracking.spec.ts
+++ b/tests/e2e/admin-shipment-tracking.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import { E2E_CUSTOMER } from './global-setup';
+import { loginAsCustomer } from './helpers/auth';
+import {
+	deleteOrder,
+	seedShipmentTracking,
+	seedTestOrder,
+} from './helpers/orders';
+import { wp } from './helpers/wp-cli';
+
+/**
+ * Manual shipment tracking persists `Shipment_Data` against the order
+ * (courier_id, courier_title, tracking_num, tracking_url) via
+ * `Helper::new_order_shipment_data`. The customer's view-order page
+ * surfaces it through `class-my-account.php::add_tracking_info_to_order_details`.
+ *
+ * The admin metabox UI is hepsijet-aware and quite involved; we
+ * exercise the underlying Helper API (the same call the metabox AJAX
+ * handler ends up making) and assert the customer-facing rendering,
+ * which is what actually matters when something regresses.
+ */
+let orderId: string;
+let customerId: string;
+
+test.describe( 'Hezarfen manuel kargo takibi', () => {
+	test.beforeAll( () => {
+		customerId = wp( [
+			'user',
+			'get',
+			E2E_CUSTOMER.username,
+			'--field=ID',
+		] ).trim();
+		orderId = seedTestOrder( {
+			status: 'processing',
+			customerEmail: E2E_CUSTOMER.email,
+			customerId,
+		} );
+	} );
+	test.afterAll( () => {
+		deleteOrder( orderId );
+	} );
+
+	test( 'admin shipment metabox sipariş düzenleme ekranında görünür', async ( {
+		page,
+	} ) => {
+		// Login via customer login form would not work for admin; we
+		// reuse the login helper for the e2e admin user defined in
+		// global-setup.
+		const { loginAsAdmin } = await import( './helpers/auth' );
+		await loginAsAdmin( page );
+		await page.goto(
+			`/wp-admin/admin.php?page=wc-orders&action=edit&id=${ orderId }`
+		);
+		await expect(
+			page.locator( '#hez-order-shipments' )
+		).toBeAttached();
+		// Lite (manual) tab must be present even if Pro panel is hidden.
+		await expect(
+			page.locator( '#hezarfen-lite-tab' )
+		).toBeAttached();
+		// Two `#shipping-companies` lists render — one in the Lite
+		// (manual) tab, one in the Pro tab. Either being attached is
+		// fine for our regression check.
+		await expect(
+			page.locator( '#shipping-companies' ).first()
+		).toBeAttached();
+	} );
+
+	test( 'kaydedilen tracking bilgisi müşterinin view-order sayfasında görünüyor', async ( {
+		page,
+	} ) => {
+		seedShipmentTracking( {
+			orderId,
+			courierId: 'aras',
+			trackingNum: 'TR123456789',
+		} );
+
+		await loginAsCustomer( page );
+		await page.goto( `/my-account/view-order/${ orderId }/` );
+
+		// "Aras Kargo" ile "TR123456789" sayfada görünmeli.
+		await expect( page.locator( 'body' ) ).toContainText( /aras/i );
+		await expect( page.locator( 'body' ) ).toContainText( 'TR123456789' );
+		// Tracking link da olmalı.
+		await expect(
+			page.locator( 'a.tracking-url, a[href*="aras"]' ).first()
+		).toBeVisible();
+	} );
+} );

--- a/tests/e2e/checkout-bacs.spec.ts
+++ b/tests/e2e/checkout-bacs.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+import {
+	addE2EProductToCart,
+	expectCheckoutUpdate,
+	fillTrAddressChain,
+	TR_SAMPLE_ADDRESS,
+	waitForCheckoutIdle,
+} from './helpers/checkout';
+import { wp } from './helpers/wp-cli';
+
+/**
+ * Sanity check that orders go through with the bank-transfer (BACS)
+ * gateway, not just COD. Hezarfen's payment_method-aware code paths
+ * (TC encryption order-meta hooks etc.) sometimes assume COD; this
+ * test catches that class of regression and confirms the BACS
+ * thank-you page renders the bank instructions block.
+ */
+test.describe( 'Hezarfen — BACS (banka havalesi) gateway', () => {
+	test.beforeAll( () => {
+		// Enable BACS for this describe; restore in afterAll. We can't
+		// just snapshotOptions on woocommerce_bacs_settings because it's
+		// a serialised array; the easier path is to flip the enabled
+		// flag through wc payment_gateway update.
+		wp( [
+			'wc',
+			'payment_gateway',
+			'update',
+			'bacs',
+			'--user=1',
+			'--enabled=true',
+			'--title=Banka havalesi (e2e)',
+			'--description=Lütfen ödemenizi banka hesabımıza yapınız.',
+		] );
+	} );
+	test.afterAll( () => {
+		wp(
+			[
+				'wc',
+				'payment_gateway',
+				'update',
+				'bacs',
+				'--user=1',
+				'--enabled=false',
+			],
+			{ allowFailure: true }
+		);
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'BACS ile sipariş geçince thank-you sayfasında banka talimatı görünüyor', async ( {
+		page,
+	} ) => {
+		await page.goto( '/checkout/' );
+		await waitForCheckoutIdle( page );
+		await fillTrAddressChain( page, {
+			type: 'billing',
+			cityPlate: TR_SAMPLE_ADDRESS.cityPlate,
+			district: TR_SAMPLE_ADDRESS.district,
+			neighborhood: TR_SAMPLE_ADDRESS.neighborhood,
+		} );
+		await page.locator( '#billing_first_name' ).fill( 'Ada' );
+		await page.locator( '#billing_last_name' ).fill( 'Lovelace' );
+		await page.locator( '#billing_email' ).fill( 'ada@example.test' );
+		await page.locator( '#billing_phone' ).fill( '5551112233' );
+		const postcode = page.locator( '#billing_postcode' );
+		if ( await postcode.isVisible() ) {
+			await postcode.fill( TR_SAMPLE_ADDRESS.postcode );
+		}
+		await page
+			.locator( '#billing_address_2' )
+			.fill( TR_SAMPLE_ADDRESS.street );
+		await page.locator( '#billing_address_2' ).blur();
+		await expectCheckoutUpdate( page ).catch( () => {} );
+		await waitForCheckoutIdle( page );
+
+		// Pick BACS instead of COD.
+		const bacs = page.locator( '#payment_method_bacs' );
+		await expect( bacs ).toBeVisible();
+		await bacs.check( { force: true } );
+		await expect( bacs ).toBeChecked();
+
+		await waitForCheckoutIdle( page );
+		await page.locator( '#place_order' ).click();
+		await page.waitForURL( /order-received/, { timeout: 30_000 } );
+
+		// BACS-specific block: WC outputs `.wc-bacs-bank-details` /
+		// "Direct bank transfer" instructions. We accept either the
+		// Turkish translation or the English source string.
+		await expect( page.locator( 'body' ) ).toContainText(
+			/(banka havalesi|direct bank transfer|bank account)/i
+		);
+		// Order summary still shows our gateway title.
+		await expect(
+			page.locator( '.woocommerce-order-overview, ul.order_details' )
+		).toContainText( /(banka|bank)/i );
+	} );
+} );

--- a/tests/e2e/checkout-contracts.spec.ts
+++ b/tests/e2e/checkout-contracts.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '@playwright/test';
+import {
+	addE2EProductToCart,
+	expectCheckoutUpdate,
+	fillTrAddressChain,
+	TR_SAMPLE_ADDRESS,
+	waitForCheckoutIdle,
+} from './helpers/checkout';
+import {
+	applyOptions,
+	restoreOptions,
+	snapshotOptions,
+} from './helpers/wp-options';
+
+/**
+ * Hezarfen's contracts module renders one or more required checkboxes
+ * (Mesafeli Satış Sözleşmesi + Ön Bilgilendirme Formu) on the checkout
+ * via `woocommerce_checkout_after_terms_and_conditions`. The combined
+ * variant lives at `input[name="contract_combined_checkbox"]`. Both
+ * variants carry the `required` attribute, so submitting unchecked
+ * trips the browser's HTML5 validity check before WC ever sees the
+ * POST. We assert both: presence + that the order does NOT reach the
+ * thank-you page if the checkbox is left unchecked.
+ */
+const FEATURE_OPTIONS = {
+	hezarfen_contracts_enabled: 'yes',
+};
+
+let snapshot: Record< string, string >;
+
+test.describe( 'Hezarfen MSS / Ön Bilgilendirme sözleşmeleri', () => {
+	test.beforeAll( () => {
+		snapshot = snapshotOptions( Object.keys( FEATURE_OPTIONS ) );
+		applyOptions( FEATURE_OPTIONS );
+	} );
+	test.afterAll( () => {
+		restoreOptions( snapshot );
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'sözleşme checkbox\'ı zorunlu, işaretlemeden sipariş geçmiyor', async ( {
+		page,
+	} ) => {
+		await page.goto( '/checkout/' );
+		await waitForCheckoutIdle( page );
+		await fillCheckoutWithoutContracts( page );
+
+		// Combined or per-contract checkbox must exist.
+		const checkbox = page
+			.locator(
+				'input[name="contract_combined_checkbox"], input[name^="contract_"][type="checkbox"]'
+			)
+			.first();
+		await expect( checkbox ).toBeAttached();
+		await expect( checkbox ).not.toBeChecked();
+		const isRequired = await checkbox.evaluate(
+			( el ) => ( el as HTMLInputElement ).required
+		);
+		expect( isRequired ).toBe( true );
+
+		// Click place order without ticking — browser HTML5 validation
+		// should keep us on /checkout/ and the checkbox should report
+		// as invalid.
+		await page.locator( '#place_order' ).click();
+		await page.waitForLoadState( 'networkidle' );
+		expect( page.url() ).toMatch( /checkout/i );
+		const isValid = await checkbox.evaluate(
+			( el ) => ( el as HTMLInputElement ).validity.valid
+		);
+		expect( isValid ).toBe( false );
+	} );
+
+	test( 'sözleşme checkbox\'ı işaretlenince sipariş başarıyla geçiyor', async ( {
+		page,
+	} ) => {
+		await page.goto( '/checkout/' );
+		await waitForCheckoutIdle( page );
+		await fillCheckoutWithoutContracts( page );
+
+		const checkbox = page
+			.locator(
+				'input[name="contract_combined_checkbox"], input[name^="contract_"][type="checkbox"]'
+			)
+			.first();
+		await checkbox.check( { force: true } );
+		await expect( checkbox ).toBeChecked();
+
+		await waitForCheckoutIdle( page );
+		await page.locator( '#place_order' ).click();
+		await page.waitForURL( /order-received/, { timeout: 30_000 } );
+		await expect( page.locator( 'body' ) ).toContainText(
+			/(siparişiniz alın|order has been received)/i
+		);
+	} );
+} );
+
+async function fillCheckoutWithoutContracts(
+	page: import( '@playwright/test' ).Page
+): Promise< void > {
+	await fillTrAddressChain( page, {
+		type: 'billing',
+		cityPlate: TR_SAMPLE_ADDRESS.cityPlate,
+		district: TR_SAMPLE_ADDRESS.district,
+		neighborhood: TR_SAMPLE_ADDRESS.neighborhood,
+	} );
+	await page.locator( '#billing_first_name' ).fill( 'Ada' );
+	await page.locator( '#billing_last_name' ).fill( 'Lovelace' );
+	await page.locator( '#billing_email' ).fill( 'ada@example.test' );
+	await page.locator( '#billing_phone' ).fill( '5551112233' );
+	const postcode = page.locator( '#billing_postcode' );
+	if ( await postcode.isVisible() ) {
+		await postcode.fill( TR_SAMPLE_ADDRESS.postcode );
+	}
+	await page.locator( '#billing_address_2' ).fill( TR_SAMPLE_ADDRESS.street );
+	await page.locator( '#billing_address_2' ).blur();
+	await expectCheckoutUpdate( page ).catch( () => {} );
+	await waitForCheckoutIdle( page );
+	const cod = page.locator( '#payment_method_cod' );
+	if ( await cod.isVisible() ) {
+		await cod.check( { force: true } );
+	}
+}

--- a/tests/e2e/checkout-country-switch.spec.ts
+++ b/tests/e2e/checkout-country-switch.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+import {
+	addE2EProductToCart,
+	expectMahalleAjax,
+	pickFromSelect,
+	TR_SAMPLE_ADDRESS,
+	waitForCheckoutIdle,
+} from './helpers/checkout';
+
+/**
+ * `mahalle-helper.js` swaps billing_city / billing_address_1 between
+ * <select> (TR — Hezarfen-driven mahalle dropdowns) and <input> (any
+ * other country — fall back to plain text). The `country_to_state_changing`
+ * event is what triggers the swap, see assets/js/mahalle-helper.js.
+ *
+ * If we ever break that branch, customers from non-TR countries get
+ * empty selects with no text input — they can't enter their address.
+ * This spec catches that.
+ */
+test.describe( 'Hezarfen ülke değişimi davranışı', () => {
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'TR seçiliyken city/address_1 select; başka ülkeye geçince input', async ( {
+		page,
+	} ) => {
+		await page.goto( '/checkout/' );
+		await waitForCheckoutIdle( page );
+
+		// Default country = TR (set by global-setup). City/address_1 are
+		// rendered as selects by Hezarfen's checkout-fields filter.
+		await expect( page.locator( '#billing_country' ) ).toHaveValue( 'TR' );
+		await expect(
+			page.locator( 'select#billing_city' )
+		).toBeAttached();
+		await expect(
+			page.locator( 'select#billing_address_1' )
+		).toBeAttached();
+
+		// Pick Ankara so the chain is exercised on the TR branch.
+		const districtPromise = expectMahalleAjax( page, 'district' );
+		await pickFromSelect(
+			page,
+			'#billing_state',
+			TR_SAMPLE_ADDRESS.cityPlate
+		);
+		await districtPromise;
+
+		// Switch country to United States — country_to_state_changing
+		// fires, mahalle-helper replaces both selects with text inputs.
+		await pickFromSelect( page, '#billing_country', 'US' );
+		await waitForCheckoutIdle( page );
+
+		// city / address_1 must now be plain inputs, not selects.
+		await expect( page.locator( 'input#billing_city' ) ).toBeAttached();
+		await expect(
+			page.locator( 'input#billing_address_1' )
+		).toBeAttached();
+		await expect( page.locator( 'select#billing_city' ) ).toHaveCount( 0 );
+		await expect(
+			page.locator( 'select#billing_address_1' )
+		).toHaveCount( 0 );
+
+		// Switch back to TR — selects should reappear.
+		await pickFromSelect( page, '#billing_country', 'TR' );
+		await waitForCheckoutIdle( page );
+		await expect(
+			page.locator( 'select#billing_city' )
+		).toBeAttached();
+		await expect(
+			page.locator( 'select#billing_address_1' )
+		).toBeAttached();
+	} );
+} );

--- a/tests/e2e/checkout-options.spec.ts
+++ b/tests/e2e/checkout-options.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+import {
+	addE2EProductToCart,
+	waitForCheckoutIdle,
+} from './helpers/checkout';
+import {
+	applyOptions,
+	restoreOptions,
+	snapshotOptions,
+} from './helpers/wp-options';
+
+/**
+ * Two checkout-shaping options exposed in Hezarfen settings:
+ *   - hezarfen_hide_checkout_postcode_fields → drops the postcode field
+ *     from billing + shipping forms.
+ *   - hezarfen_checkout_fields_auto_sort → reorders billing fields into
+ *     the TR-conventional sequence (state → city → address_1 → ...).
+ *
+ * Each test snapshots/restores the option so the rest of the suite
+ * keeps the defaults set by global-setup.
+ */
+test.describe( 'Hezarfen checkout opsiyonları', () => {
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'hezarfen_hide_checkout_postcode_fields=yes ile posta kodu alanı gizleniyor', async ( {
+		page,
+	} ) => {
+		const snap = snapshotOptions( [ 'hezarfen_hide_checkout_postcode_fields' ] );
+		applyOptions( { hezarfen_hide_checkout_postcode_fields: 'yes' } );
+
+		try {
+			await page.goto( '/checkout/' );
+			await waitForCheckoutIdle( page );
+
+			// Hezarfen hides the postcode by setting `hidden=true` on
+			// the TR locale, which makes WC tag the wrapper with a
+			// hidden class instead of removing it from the DOM. We
+			// assert it isn't visible to the user.
+			await expect(
+				page.locator( '#billing_postcode_field' )
+			).toBeHidden();
+		} finally {
+			restoreOptions( snap );
+		}
+	} );
+
+	test( 'hezarfen_checkout_fields_auto_sort=yes ile billing alanları TR sırasında', async ( {
+		page,
+	} ) => {
+		const snap = snapshotOptions( [ 'hezarfen_checkout_fields_auto_sort' ] );
+		applyOptions( { hezarfen_checkout_fields_auto_sort: 'yes' } );
+
+		try {
+			await page.goto( '/checkout/' );
+			await waitForCheckoutIdle( page );
+
+			// Read the priority/order from the rendered form. The TR
+			// canonical order is state (il) → city (ilçe) → address_1
+			// (mahalle) → address_2 (sokak/no) — that's what auto_sort
+			// has to enforce.
+			const order = await page.evaluate( () => {
+				const ids = [
+					'billing_state_field',
+					'billing_city_field',
+					'billing_address_1_field',
+					'billing_address_2_field',
+				];
+				return ids
+					.map( ( id ) => {
+						const el = document.getElementById( id );
+						return el
+							? {
+									id,
+									top: el.getBoundingClientRect().top,
+							  }
+							: null;
+					} )
+					.filter( Boolean ) as { id: string; top: number }[];
+			} );
+
+			expect( order.length ).toBe( 4 );
+			// Each subsequent field should sit lower on the page than
+			// the previous one — i.e. document order matches TR order.
+			for ( let i = 1; i < order.length; i++ ) {
+				expect.soft( order[ i ].top, `${ order[ i ].id } follows ${ order[ i - 1 ].id }` )
+					.toBeGreaterThan( order[ i - 1 ].top );
+			}
+		} finally {
+			restoreOptions( snap );
+		}
+	} );
+} );

--- a/tests/e2e/checkout-shipping-address.spec.ts
+++ b/tests/e2e/checkout-shipping-address.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from '@playwright/test';
+import {
+	addE2EProductToCart,
+	expectCheckoutUpdate,
+	expectMahalleAjax,
+	fillTrAddressChain,
+	pickFromSelect,
+	TR_SAMPLE_ADDRESS,
+	waitForCheckoutIdle,
+} from './helpers/checkout';
+
+/**
+ * When the customer ticks "Farklı bir adrese gönderilsin mi?" the
+ * shipping_state / shipping_city / shipping_address_1 fields appear
+ * and Hezarfen mirrors the same mahalle dropdown chain onto them.
+ * If the helper ever fails to bind to the shipping wrapper, customers
+ * can pick TR for shipping but get no district/neighborhood options.
+ */
+const SHIPPING = {
+	cityPlate: 'TR34',
+	city: 'İstanbul',
+	district: 'Kadıköy',
+	street: 'Bahariye Cad. No:5',
+	postcode: '34710',
+};
+
+test.describe( 'Hezarfen farklı kargo adresi', () => {
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'ship-to-different ile shipping il/ilçe/mahalle zinciri çalışıyor ve sipariş geçiyor', async ( {
+		page,
+	} ) => {
+		await page.goto( '/checkout/' );
+		await waitForCheckoutIdle( page );
+
+		// Billing first.
+		await fillTrAddressChain( page, {
+			type: 'billing',
+			cityPlate: TR_SAMPLE_ADDRESS.cityPlate,
+			district: TR_SAMPLE_ADDRESS.district,
+			neighborhood: TR_SAMPLE_ADDRESS.neighborhood,
+		} );
+		await page.locator( '#billing_first_name' ).fill( 'Ada' );
+		await page.locator( '#billing_last_name' ).fill( 'Lovelace' );
+		await page.locator( '#billing_email' ).fill( 'ada@example.test' );
+		await page.locator( '#billing_phone' ).fill( '5551112233' );
+		const billingPostcode = page.locator( '#billing_postcode' );
+		if ( await billingPostcode.isVisible() ) {
+			await billingPostcode.fill( TR_SAMPLE_ADDRESS.postcode );
+		}
+		await page
+			.locator( '#billing_address_2' )
+			.fill( TR_SAMPLE_ADDRESS.street );
+
+		// Tick ship-to-different so the shipping fields render.
+		const shipDifferent = page.locator(
+			'#ship-to-different-address-checkbox'
+		);
+		await shipDifferent.check( { force: true } );
+		await expect(
+			page.locator( '#shipping_first_name' )
+		).toBeVisible();
+
+		// Pull the first shipping neighborhood for the chosen state →
+		// district so we don't have to hard-code one. Allowing the chain
+		// to drive itself catches breakage in either AJAX hop.
+		await page.locator( '#shipping_first_name' ).fill( 'Charles' );
+		await page.locator( '#shipping_last_name' ).fill( 'Babbage' );
+
+		const districtPromise = expectMahalleAjax( page, 'district' );
+		await pickFromSelect(
+			page,
+			'#shipping_state',
+			SHIPPING.cityPlate
+		);
+		await districtPromise;
+		const districts = await page
+			.locator( '#shipping_city option' )
+			.allTextContents();
+		expect( districts ).toContain( SHIPPING.district );
+
+		const neighborhoodPromise = expectMahalleAjax( page, 'neighborhood' );
+		await pickFromSelect( page, '#shipping_city', SHIPPING.district );
+		await neighborhoodPromise;
+		const shippingNeighborhoods = await page
+			.locator( '#shipping_address_1 option' )
+			.allTextContents();
+		expect( shippingNeighborhoods.length ).toBeGreaterThan( 1 );
+		// Pick the first non-placeholder option so the test isn't tied
+		// to a specific Kadıköy mahalle name (data file changes).
+		const firstReal = shippingNeighborhoods.find(
+			( n ) => !! n && ! /seçiniz/i.test( n )
+		);
+		expect( firstReal ).toBeTruthy();
+		await pickFromSelect(
+			page,
+			'#shipping_address_1',
+			firstReal as string
+		);
+
+		await page.locator( '#shipping_address_2' ).fill( SHIPPING.street );
+		const shippingPostcode = page.locator( '#shipping_postcode' );
+		if ( await shippingPostcode.isVisible() ) {
+			await shippingPostcode.fill( SHIPPING.postcode );
+		}
+
+		await page.locator( '#billing_address_2' ).blur();
+		await expectCheckoutUpdate( page ).catch( () => {} );
+		await waitForCheckoutIdle( page );
+
+		const cod = page.locator( '#payment_method_cod' );
+		await cod.check( { force: true } );
+		await waitForCheckoutIdle( page );
+
+		await page.locator( '#place_order' ).click();
+		await page.waitForURL( /order-received/, { timeout: 30_000 } );
+		await expect( page.locator( 'body' ) ).toContainText(
+			/(siparişiniz alın|order has been received)/i
+		);
+
+		// Order received page lists the shipping address — both Kadıköy
+		// and the chosen mahalle should appear there if the form sent
+		// the right shipping_* fields.
+		const shippingAddressBlock = page
+			.locator( '.woocommerce-customer-details, address' )
+			.first();
+		await expect( shippingAddressBlock ).toContainText( SHIPPING.district );
+	} );
+} );

--- a/tests/e2e/helpers/orders.ts
+++ b/tests/e2e/helpers/orders.ts
@@ -9,16 +9,18 @@ import { wp } from './wp-cli';
 export function seedTestOrder( opts: {
 	status?: string;
 	customerEmail?: string;
+	customerId?: string;
 } = {} ): string {
 	const status = opts.status ?? 'on-hold';
 	const email = opts.customerEmail ?? 'e2e-buyer@example.test';
+	const customerId = opts.customerId ?? '0';
 
 	const out = wp( [
 		'eval',
 		`
 			$product = get_page_by_path( 'hezarfen-e2e-product', OBJECT, 'product' );
 			if ( ! $product ) { echo 'ERR_NO_PRODUCT'; return; }
-			$order = wc_create_order( array( 'status' => '${ status }' ) );
+			$order = wc_create_order( array( 'status' => '${ status }', 'customer_id' => ${ customerId } ) );
 			$order->add_product( wc_get_product( $product->ID ), 1 );
 			$order->set_billing_first_name( 'Ada' );
 			$order->set_billing_last_name( 'Lovelace' );
@@ -42,6 +44,34 @@ export function seedTestOrder( opts: {
 		throw new Error( `seedTestOrder failed: ${ out }` );
 	}
 	return out;
+}
+
+/**
+ * Save manual-shipment-tracking data on an order using the same
+ * Helper::new_order_shipment_data API the admin metabox calls. We
+ * skip the AJAX layer because the metabox UI is hepsijet-aware and
+ * involves several radios + nonces — testing storage + display is
+ * the high-value bit.
+ */
+export function seedShipmentTracking( opts: {
+	orderId: string;
+	courierId: string;
+	trackingNum: string;
+} ): void {
+	wp( [
+		'eval',
+		`
+			$order = wc_get_order( ${ opts.orderId } );
+			if ( ! $order ) { echo 'ERR_NO_ORDER'; return; }
+			\\Hezarfen\\ManualShipmentTracking\\Helper::new_order_shipment_data(
+				$order,
+				null,
+				'${ opts.courierId }',
+				'${ opts.trackingNum }'
+			);
+			echo 'OK';
+		`,
+	] );
 }
 
 export function deleteOrder( orderId: string ): void {


### PR DESCRIPTION
## Summary

Brainstorm listesinde kalan tüm akışları tek PR'a topladım. Toplam **6 yeni spec, 11 yeni test**, mevcut suite ile birlikte **20 passed + 1 fixme**.

### Yeni testler

| Spec | Testler | Ne kapsar |
| --- | --- | --- |
| **checkout-contracts.spec.ts** | 2 | MSS / Ön Bilgilendirme zorunlu checkbox: işaretsiz submit reddediliyor (HTML5 validity), check'le sipariş geçiyor |
| **checkout-country-switch.spec.ts** | 1 | TR ↔ US: city/address_1 select'leri input'a düşüyor, geri TR'de tekrar select'e dönüşüyor (mahalle-helper.js \`country_to_state_changing\` branch) |
| **checkout-shipping-address.spec.ts** | 1 | ship-to-different ile \`shipping_state/city/address_1\` zinciri çalışıyor; farklı şehre (İstanbul/Kadıköy) sipariş geçiyor; thank-you'da shipping adresi doğru |
| **checkout-bacs.spec.ts** | 1 | BACS gateway etkinleştirildiğinde sipariş geçiyor ve thank-you'da banka talimatı render oluyor |
| **checkout-options.spec.ts** | 2 | \`hezarfen_hide_checkout_postcode_fields=yes\` postcode'u gizliyor; \`hezarfen_checkout_fields_auto_sort=yes\` billing alanlarını TR sırasında diziyor (state→city→address_1→address_2) |
| **admin-shipment-tracking.spec.ts** | 2 | admin order edit'te shipment metabox attached; \`Helper::new_order_shipment_data\` ile seedlenen Aras takip bilgisi \`/my-account/view-order/{N}/\` ekranında müşteriye görünüyor (kargo başlığı + tracking_num + tracking_url) |

### Altyapı eklemesi

- **\`helpers/orders.ts::seedShipmentTracking\`** — manuel takip metabox UI'ı hepsijet-aware ve karmaşık (radio + nonce + multiple tabs); regresyon için Helper'ın kendisini çağırmak yeterli, kullanıcının görmesi gereken kısım view-order ekranında doğrulanıyor.
- **\`seedTestOrder\` customer_id parametresi** — view-order sayfası kullanıcının kendi siparişini görmesini gerektirdiği için seed sırasında customer_id set edilebiliyor.

### Suite durumu

\`\`\`
admin-order-edit              ›  4 passed
admin-shipment-tracking       ›  2 passed
checkout-bacs                 ›  1 passed
checkout-contracts            ›  2 passed
checkout-country-switch       ›  1 passed
checkout-options              ›  2 passed
checkout-shipping-address     ›  1 passed
checkout-tc-tax               ›  3 passed
checkout-tr                   ›  2 passed
my-account-address            ›  2 passed, 1 fixme (bilinen UI bug)
———
20 passed, 1 skipped (~1.8m)
\`\`\`

## Test plan
- [ ] \`npm run test:e2e:playwright\` lokal LocalWP üzerinde 20 yeşil + 1 skipped
- [ ] HPOS açıkken admin shipment tracking testleri yeşil (hepsijet pro panel hidden, lite tab açık)
- [ ] BACS testinden sonra COD tek gateway durumuna dönüyor (afterAll restore)
- [ ] MSS testinden sonra contracts opsiyonu kapanıp diğer testleri etkilemiyor (snapshot/restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)