### PR TITLE
ci: run e2e (Playwright) on develop push via wp-env

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,75 @@
+name: E2E (Playwright)
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Install composer deps (no-dev)
+        run: composer install --no-dev --optimize-autoloader
+
+      - name: Install npm deps
+        run: npm ci
+
+      - name: Build admin bundles
+        run: npm run build
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Start wp-env
+        run: npx wp-env start
+
+      - name: Run Playwright tests
+        env:
+          HEZARFEN_E2E_USE_WP_ENV: '1'
+          HEZARFEN_E2E_BASE_URL: http://localhost:8888
+        run: npx playwright test --config=tests/e2e/playwright.config.ts
+
+      - name: Stop wp-env
+        if: always()
+        run: npx wp-env stop || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/e2e/playwright-report
+          retention-days: 14
+
+      - name: Upload test results (failures)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: tests/e2e/test-results
+          retention-days: 14

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,16 @@
+{
+	"core": null,
+	"phpVersion": "8.2",
+	"plugins": [
+		"https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip",
+		"."
+	],
+	"themes": [
+		"https://downloads.wordpress.org/theme/storefront.latest-stable.zip"
+	],
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": false
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hezarfen-for-woocommerce",
-  "version": "1.5.0",
+  "version": "2.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hezarfen-for-woocommerce",
-      "version": "1.5.0",
+      "version": "2.8.3",
       "license": "GPLV2",
       "dependencies": {
         "@preline/tabs": "^2.1.0",
@@ -15,8 +15,10 @@
         "tailwindcss-scoped-preflight": "^3.2.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.43.0",
         "@prettier/plugin-php": "^0.15.2",
         "@tailwindcss/forms": "^0.5.7",
+        "@wordpress/env": "^9.10.0",
         "@wordpress/scripts": "^27.7.0",
         "autoprefixer": "^10.4.19",
         "install": "^0.13.0",
@@ -2842,6 +2844,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -2937,7 +2956,6 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
       "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "playwright": "1.43.1"
       },
@@ -3278,11 +3296,41 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
@@ -3571,6 +3619,19 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
@@ -3698,6 +3759,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3786,6 +3860,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -3848,6 +3929,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -3907,6 +3998,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -4698,6 +4799,126 @@
       },
       "peerDependencies": {
         "@playwright/test": ">=1"
+      }
+    },
+    "node_modules/@wordpress/env": {
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.10.0.tgz",
+      "integrity": "sha512-GqUg1XdrUXI3l5NhHhEZisrccW+VPqJSU5xO1IXybI6KOvmSecidxWEqlMj26vzu2P5aLCWZcx28QkrrY3jvdg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "copy-dir": "^1.3.0",
+        "docker-compose": "^0.24.3",
+        "extract-zip": "^1.6.7",
+        "got": "^11.8.5",
+        "inquirer": "^7.1.0",
+        "js-yaml": "^3.13.1",
+        "ora": "^4.0.2",
+        "rimraf": "^3.0.2",
+        "simple-git": "^3.5.0",
+        "terminal-link": "^2.0.0",
+        "yargs": "^17.3.0"
+      },
+      "bin": {
+        "wp-env": "bin/wp-env"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/extract-zip": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/env/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@wordpress/hooks": {
@@ -6307,6 +6528,51 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -6494,6 +6760,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-node-version": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
@@ -6646,6 +6919,42 @@
         "webpack": "*"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6733,6 +7042,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clone-deep": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -6747,6 +7066,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/co": {
@@ -6891,6 +7223,62 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -6987,6 +7375,13 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/copy-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+      "integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
       "version": "10.2.4",
@@ -7650,6 +8045,35 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -7698,6 +8122,29 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -7971,6 +8418,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docker-compose": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/doctrine": {
@@ -9367,6 +9827,34 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -9503,6 +9991,32 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -10253,6 +10767,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -10521,6 +11061,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -10608,6 +11155,33 @@
         "@types/express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -10823,6 +11397,96 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/install": {
       "version": "0.13.0",
@@ -11138,6 +11802,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-map": {
@@ -13056,6 +13730,16 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -13517,6 +14201,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -13704,6 +14398,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -13737,6 +14444,13 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -13937,6 +14651,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm": {
@@ -17260,6 +17987,173 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.2.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^3.0.0",
+        "mute-stream": "0.0.8",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -17267,6 +18161,26 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-defer": {
@@ -17718,7 +18632,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
       "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.43.1"
       },
@@ -17737,7 +18650,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
       "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -17755,7 +18667,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -19554,6 +20465,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-bin": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.3.tgz",
@@ -19605,6 +20523,40 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -19685,6 +20637,16 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/run-con": {
@@ -20226,6 +21188,49 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/simple-git/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sirv": {
       "version": "2.0.4",
@@ -21415,6 +22420,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/terser": {
       "version": "5.30.4",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
@@ -21625,6 +22647,19 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -21931,6 +22966,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -22302,6 +23344,16 @@
       "dev": true,
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "test:e2e:playwright": "playwright test --config=tests/e2e/playwright.config.ts",
     "test:e2e:playwright:install": "playwright install chromium",
     "test:e2e:playwright:report": "playwright show-report tests/e2e/playwright-report",
+    "test:e2e:wp-env:start": "wp-env start",
+    "test:e2e:wp-env:stop": "wp-env stop",
+    "test:e2e:wp-env:run": "HEZARFEN_E2E_USE_WP_ENV=1 HEZARFEN_E2E_BASE_URL=http://localhost:8888 playwright test --config=tests/e2e/playwright.config.ts",
     "test:unit": "wp-scripts test-unit-js"
   },
   "repository": {
@@ -42,6 +45,7 @@
     "@playwright/test": "^1.43.0",
     "@prettier/plugin-php": "^0.15.2",
     "@tailwindcss/forms": "^0.5.7",
+    "@wordpress/env": "^9.10.0",
     "@wordpress/scripts": "^27.7.0",
     "autoprefixer": "^10.4.19",
     "install": "^0.13.0",

--- a/tests/e2e/admin-shipment-tracking.spec.ts
+++ b/tests/e2e/admin-shipment-tracking.spec.ts
@@ -54,13 +54,10 @@ test.describe( 'Hezarfen manuel kargo takibi', () => {
 		await expect(
 			page.locator( '#hez-order-shipments' )
 		).toBeAttached();
-		// Lite (manual) tab must be present even if Pro panel is hidden.
-		await expect(
-			page.locator( '#hezarfen-lite-tab' )
-		).toBeAttached();
-		// Two `#shipping-companies` lists render — one in the Lite
-		// (manual) tab, one in the Pro tab. Either being attached is
-		// fine for our regression check.
+		// The pro/lite tab toggle only renders when Hezarfen Pro is
+		// active, so we skip asserting on the tab buttons. The manual
+		// courier picker is always present and is the bit that
+		// actually drives the regression check.
 		await expect(
 			page.locator( '#shipping-companies' ).first()
 		).toBeAttached();

--- a/tests/e2e/checkout-shipping-address.spec.ts
+++ b/tests/e2e/checkout-shipping-address.spec.ts
@@ -7,6 +7,7 @@ import {
 	pickFromSelect,
 	TR_SAMPLE_ADDRESS,
 	waitForCheckoutIdle,
+	waitForOptionsPopulated,
 } from './helpers/checkout';
 
 /**
@@ -20,6 +21,7 @@ const SHIPPING = {
 	cityPlate: 'TR34',
 	city: 'İstanbul',
 	district: 'Kadıköy',
+	neighborhood: '19 Mayıs Mah',
 	street: 'Bahariye Cad. No:5',
 	postcode: '34710',
 };
@@ -76,6 +78,7 @@ test.describe( 'Hezarfen farklı kargo adresi', () => {
 			SHIPPING.cityPlate
 		);
 		await districtPromise;
+		await waitForOptionsPopulated( page, '#shipping_city' );
 		const districts = await page
 			.locator( '#shipping_city option' )
 			.allTextContents();
@@ -84,20 +87,17 @@ test.describe( 'Hezarfen farklı kargo adresi', () => {
 		const neighborhoodPromise = expectMahalleAjax( page, 'neighborhood' );
 		await pickFromSelect( page, '#shipping_city', SHIPPING.district );
 		await neighborhoodPromise;
+		await waitForOptionsPopulated( page, '#shipping_address_1' );
 		const shippingNeighborhoods = await page
 			.locator( '#shipping_address_1 option' )
 			.allTextContents();
-		expect( shippingNeighborhoods.length ).toBeGreaterThan( 1 );
-		// Pick the first non-placeholder option so the test isn't tied
-		// to a specific Kadıköy mahalle name (data file changes).
-		const firstReal = shippingNeighborhoods.find(
-			( n ) => !! n && ! /seçiniz/i.test( n )
+		expect( shippingNeighborhoods ).toContain(
+			SHIPPING.neighborhood
 		);
-		expect( firstReal ).toBeTruthy();
 		await pickFromSelect(
 			page,
 			'#shipping_address_1',
-			firstReal as string
+			SHIPPING.neighborhood
 		);
 
 		await page.locator( '#shipping_address_2' ).fill( SHIPPING.street );

--- a/tests/e2e/fixtures/enable-hpos.php
+++ b/tests/e2e/fixtures/enable-hpos.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * One-shot enable HPOS for the e2e wp-env stack. Called via
+ * `wp eval-file` from global-setup.ts when running in wp-env mode.
+ */
+$container = wc_get_container();
+$ds = $container->get( \Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class );
+if ( ! $ds->check_orders_table_exists() ) {
+	$ds->create_database_tables();
+}
+
+// WC's CustomOrdersTableController guards `pre_update_option_woocommerce_custom_orders_table_enabled`
+// against any pending-sync state. There's a documented testing filter
+// for this exact scenario — flip it on, write the options, flip off.
+add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+update_option( 'woocommerce_custom_orders_table_created', 'yes' );
+update_option( 'woocommerce_custom_orders_table_enabled', 'yes' );
+update_option( 'woocommerce_feature_custom_order_tables_enabled', 'yes' );
+update_option( 'woocommerce_custom_orders_table_data_sync_enabled', 'no' );
+remove_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
+echo 'HPOS enabled';

--- a/tests/e2e/fixtures/seed-encryption-tester.php
+++ b/tests/e2e/fixtures/seed-encryption-tester.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Mark Hezarfen's encryption key as generated and store the canonical
+ * tester ciphertext (encrypted form of "Istanbul"). Called via
+ * `wp eval-file` AFTER `wp config set HEZARFEN_ENCRYPTION_KEY '…'`
+ * so the constant is already defined for this PHP request.
+ */
+update_option( 'hezarfen_encryption_key_generated', 'yes' );
+$enc = new \Hezarfen\Inc\Data\PostMetaEncryption();
+update_option( 'hezarfen_encryption_tester_text', $enc->encrypt( 'Istanbul' ) );
+echo 'encryption tester seeded';

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -16,6 +16,12 @@ export default async function globalSetup( _config: FullConfig ): Promise< void 
 
 	wp( [ 'plugin', 'activate', 'woocommerce', 'hezarfen-for-woocommerce' ] );
 
+	ensureWooCommercePages();
+	ensurePrettyPermalinks();
+	ensureHezarfenEncryptionKey();
+	ensureMssContracts();
+	ensureHPOSEnabled();
+
 	wp( [ 'option', 'update', 'woocommerce_default_country', 'TR:TR06' ] );
 	wp( [ 'option', 'update', 'woocommerce_currency', 'TRY' ] );
 	wp( [ 'option', 'update', 'woocommerce_enable_guest_checkout', 'yes' ] );
@@ -37,6 +43,167 @@ export default async function globalSetup( _config: FullConfig ): Promise< void 
 	ensureClassicCheckoutPage();
 	ensureE2ECustomer();
 	ensureE2EAdmin();
+}
+
+/**
+ * Make sure the WooCommerce-managed pages (Cart, Checkout, My Account,
+ * Shop) exist and their IDs are pinned to the matching options. On a
+ * fresh wp-env install WC's `WC_Install::install()` won't have run
+ * because wp-env activates plugins during DB-less runtime — pages
+ * end up missing and downstream wp-cli calls (`option get
+ * woocommerce_checkout_page_id`) return 0. Idempotent on existing
+ * sites (LocalWP) since `create_pages()` checks before inserting.
+ */
+function ensureWooCommercePages(): void {
+	wp( [
+		'eval',
+		`if ( class_exists( 'WC_Install' ) ) { WC_Install::create_pages(); }`,
+	] );
+}
+
+/**
+ * Default WP installs use plain "?p=N" permalinks, which return 404 for
+ * /checkout/ etc. Test specs hit those slugs directly, so we switch to
+ * pretty permalinks and flush rewrites once. Idempotent.
+ */
+/**
+ * Hezarfen's TC Identity field is rendered ONLY when
+ * `PostMetaEncryption::health_check()` passes — that wants both
+ * the `hezarfen_encryption_key_generated` option set to "yes" AND
+ * the `HEZARFEN_ENCRYPTION_KEY` constant defined in wp-config.php.
+ * On a real LocalWP install this is one-time admin UI work; for a
+ * fresh wp-env we automate it. Idempotent on existing sites.
+ */
+function ensureHezarfenEncryptionKey(): void {
+	const generated = wp(
+		[ 'option', 'get', 'hezarfen_encryption_key_generated' ],
+		{ allowFailure: true }
+	).trim();
+	if ( generated === 'yes' ) return;
+
+	// Generate a key with the same routine the plugin uses internally.
+	const key = wp( [
+		'eval',
+		`echo base64_encode( openssl_random_pseudo_bytes( 64 ) );`,
+	] ).trim();
+
+	// Pin it as a constant in wp-config.php so future requests can
+	// read it. wp config set defaults to a quoted string constant
+	// when no --type is given.
+	wp( [ 'config', 'set', 'HEZARFEN_ENCRYPTION_KEY', key ] );
+
+	// Now mark the option + write a tester ciphertext. The constant
+	// is now in wp-config.php so the next wp-cli request will see it.
+	wp( [
+		'eval-file',
+		'wp-content/plugins/hezarfen-for-woocommerce/tests/e2e/fixtures/seed-encryption-tester.php',
+	] );
+}
+
+/**
+ * Seed the MSS / OBF contracts settings so the contracts spec finds
+ * a checkbox to validate. We hand it the same shape Hezarfen's
+ * settings UI would persist: two contracts, both rendered in the
+ * combined-checkbox layout.
+ */
+function ensureMssContracts(): void {
+	const existing = wp(
+		[ 'option', 'get', 'hezarfen_mss_settings' ],
+		{ allowFailure: true }
+	).trim();
+	if ( existing && existing.includes( 'mesafeli' ) ) return;
+
+	// Use a "Sample Page" or any published page as the contract
+	// template — the renderer just needs a valid post id with content.
+	const templateId = wp( [
+		'post',
+		'list',
+		'--post_type=page',
+		'--post_status=publish',
+		'--field=ID',
+		'--posts_per_page=1',
+	] )
+		.trim()
+		.split( '\n' )[ 0 ];
+
+	wp( [
+		'eval',
+		`
+			update_option( 'hezarfen_mss_settings', array(
+				'agreement_creation_timing' => 'processing',
+				'odeme_sayfasinda_sozlesme_gosterim_tipi' => 'modal',
+				'contracts' => array(
+					array(
+						'name' => 'Mesafeli Satış Sözleşmesi',
+						'template_id' => '${ templateId }',
+						'enabled' => '1',
+						'show_in_checkbox' => '1',
+						'id' => 'mss',
+					),
+					array(
+						'name' => 'Ön Bilgilendirme Formu',
+						'template_id' => '${ templateId }',
+						'enabled' => '1',
+						'show_in_checkbox' => '1',
+						'id' => 'obf',
+					),
+				),
+			) );
+		`,
+	] );
+}
+
+/**
+ * Make sure HPOS (High-Performance Order Storage) is on. The
+ * admin-order-edit specs hit /wp-admin/admin.php?page=wc-orders which
+ * only exists when HPOS is enabled, and on a fresh wp-env install WC
+ * defaults to legacy CPT order storage.
+ */
+function ensureHPOSEnabled(): void {
+	const current = wp(
+		[ 'option', 'get', 'woocommerce_custom_orders_table_enabled' ],
+		{ allowFailure: true }
+	).trim();
+	if ( current === 'yes' ) return;
+	// Use string-form FQCNs ('Foo\\Bar\\Baz') and let `class_exists`
+	// resolve them — that avoids escaping a backslash through TS →
+	// argv → PHP eval, which is brittle.
+	// Backslash-heavy PHP code is brittle to escape through TS → argv
+	// → wp-cli eval. Hand it off to `wp eval-file` with a real PHP
+	// file on disk. Path is relative to the WP root, which works in
+	// both LocalWP (real fs) and wp-env (container fs) since the
+	// plugin sits under wp-content/plugins/ in either case.
+	wp( [
+		'eval-file',
+		'wp-content/plugins/hezarfen-for-woocommerce/tests/e2e/fixtures/enable-hpos.php',
+	] );
+}
+
+function ensurePrettyPermalinks(): void {
+	wp( [ 'rewrite', 'structure', '/%postname%/', '--hard' ] );
+	wp( [ 'rewrite', 'flush', '--hard' ] );
+	// On wp-env the cli container runs as a different unix user than
+	// the wordpress container, so `wp rewrite flush --hard` silently
+	// fails to write /var/www/html/.htaccess. Drop the canonical
+	// WP-generated .htaccess directly via PHP inside the WP runtime.
+	wp( [
+		'eval',
+		`
+			$path = ABSPATH . '.htaccess';
+			$rules = "# BEGIN WordPress\\n" .
+				"<IfModule mod_rewrite.c>\\n" .
+				"RewriteEngine On\\n" .
+				"RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]\\n" .
+				"RewriteBase /\\n" .
+				"RewriteRule ^index\\\\.php$ - [L]\\n" .
+				"RewriteCond %{REQUEST_FILENAME} !-f\\n" .
+				"RewriteCond %{REQUEST_FILENAME} !-d\\n" .
+				"RewriteRule . /index.php [L]\\n" .
+				"</IfModule>\\n" .
+				"# END WordPress\\n";
+			file_put_contents( $path, $rules );
+		`,
+	] );
 }
 
 /**

--- a/tests/e2e/helpers/checkout.ts
+++ b/tests/e2e/helpers/checkout.ts
@@ -117,12 +117,36 @@ export async function fillTrAddressChain(
 	const districtPromise = expectMahalleAjax( page, 'district' );
 	await pickFromSelect( page, `#${ type }_state`, cityPlate );
 	await districtPromise;
+	await waitForOptionsPopulated( page, `#${ type }_city` );
 
 	const neighborhoodPromise = expectMahalleAjax( page, 'neighborhood' );
 	await pickFromSelect( page, `#${ type }_city`, district );
 	await neighborhoodPromise;
+	await waitForOptionsPopulated( page, `#${ type }_address_1` );
 
 	await pickFromSelect( page, `#${ type }_address_1`, neighborhood );
+}
+
+/**
+ * The mahalle AJAX response hands the options off to a `for…of` loop in
+ * `mahalle-helper.js` — there's a microtask gap between the HTTP
+ * response (which `expectMahalleAjax` resolves on) and the moment the
+ * <option> elements actually exist in the DOM. On a fast LocalWP run
+ * we usually win that race; on a slower wp-env CI run we don't. Wait
+ * explicitly for the options to land before reading or selecting.
+ */
+export async function waitForOptionsPopulated(
+	page: Page,
+	selector: string
+): Promise< void > {
+	await page.waitForFunction(
+		( sel ) => {
+			const el = document.querySelector< HTMLSelectElement >( sel );
+			return !! el && el.options.length > 1;
+		},
+		selector,
+		{ timeout: 10_000 }
+	);
 }
 
 export const TR_SAMPLE_ADDRESS = {

--- a/tests/e2e/helpers/wp-cli.ts
+++ b/tests/e2e/helpers/wp-cli.ts
@@ -98,10 +98,24 @@ export interface WpCliOptions {
 	stdin?: string;
 }
 
+const USE_WP_ENV = process.env.HEZARFEN_E2E_USE_WP_ENV === '1';
+
 /**
- * Run a wp-cli command for the LocalWP site. Returns trimmed stdout.
+ * Run a wp-cli command. Two modes:
+ *   - Default: against the LocalWP site this checkout sits in.
+ *   - HEZARFEN_E2E_USE_WP_ENV=1: against the @wordpress/env Docker
+ *     stack (used in CI). We invoke `npx wp-env run cli wp …`,
+ *     redirect wp-env's own progress chatter to stderr, and capture
+ *     the actual wp-cli stdout.
  */
 export function wp( args: string[], opts: WpCliOptions = {} ): string {
+	if ( USE_WP_ENV ) {
+		return wpViaWpEnv( args, opts );
+	}
+	return wpViaLocalWp( args, opts );
+}
+
+function wpViaLocalWp( args: string[], opts: WpCliOptions ): string {
 	const env = {
 		...process.env,
 		...wpEnv(),
@@ -126,6 +140,62 @@ export function wp( args: string[], opts: WpCliOptions = {} ): string {
 			`wp ${ args.join( ' ' ) } failed:\n${ stderr || e.message }`
 		);
 	}
+}
+
+function wpViaWpEnv( args: string[], opts: WpCliOptions ): string {
+	// Resolve node_modules/.bin/wp-env directly so we don't go through
+	// npm/npx wrappers that prepend "> pkg@x.y.z scriptname" banners
+	// to stdout.
+	const wpEnvBin = path.resolve(
+		__dirname,
+		'..',
+		'..',
+		'..',
+		'node_modules',
+		'.bin',
+		'wp-env'
+	);
+	try {
+		const out = execFileSync(
+			wpEnvBin,
+			[ 'run', 'cli', '--', 'wp', ...args ],
+			{
+				encoding: 'utf8',
+				input: opts.stdin,
+				stdio: opts.stdin
+					? [ 'pipe', 'pipe', 'pipe' ]
+					: [ 'ignore', 'pipe', 'pipe' ],
+			}
+		);
+		return stripWpEnvNoise( out ).trim();
+	} catch ( e: any ) {
+		if ( opts.allowFailure ) {
+			return stripWpEnvNoise( e.stdout?.toString?.() || '' ).trim();
+		}
+		const stderr = e.stderr?.toString?.() || '';
+		throw new Error(
+			`wp ${ args.join( ' ' ) } (wp-env) failed:\n${ stderr || e.message }`
+		);
+	}
+}
+
+/**
+ * Some wp-env versions still leak progress chatter onto stdout
+ * (ℹ Starting / ✔ Ran). Drop those lines defensively so callers
+ * always see plain wp-cli output.
+ */
+function stripWpEnvNoise( raw: string ): string {
+	return raw
+		.split( '\n' )
+		.filter( ( line ) => {
+			const trimmed = line.trimStart();
+			if ( trimmed.startsWith( 'ℹ' ) ) return false;
+			if ( trimmed.startsWith( '✔' ) ) return false;
+			if ( trimmed.startsWith( 'Starting' ) ) return false;
+			if ( trimmed.startsWith( 'Ran ' ) ) return false;
+			return true;
+		} )
+		.join( '\n' );
 }
 
 export function wpJson< T = unknown >(


### PR DESCRIPTION
## Summary

E2E suite şimdi GitHub Actions üzerinde develop'a yapılan her push'ta otomatik koşacak. CI tarafında WordPress ortamı LocalWP'ye değil, Docker tabanlı [\`@wordpress/env\`](https://www.npmjs.com/package/@wordpress/env)'a tutturuldu — lokalde LocalWP ile çalışmaya devam ediyor.

## Yapılanlar

### Workflow

[\`.github/workflows/e2e.yml\`](.github/workflows/e2e.yml) — \`push\`/\`pull_request\` to \`develop\` (+ manuel dispatch). Ubuntu runner üzerinde:

1. composer install (no-dev) + npm ci + admin bundle build
2. \`npx playwright install --with-deps chromium\`
3. \`npx wp-env start\` (WP + WC + Storefront + bu plugin)
4. \`HEZARFEN_E2E_USE_WP_ENV=1 npx playwright test\`
5. \`npx wp-env stop\` (always)
6. Playwright HTML report + failure artifact upload

Concurrency-gated per ref → eski run'ları yeni push iptal ediyor.

### wp-env config

[\`.wp-env.json\`](.wp-env.json) — minimal: latest WP, PHP 8.2, plugin (\".\"), WooCommerce + Storefront wp.org zip'lerinden. Plugin sırası WC önce gelecek şekilde ayarlandı (Hezarfen WC dependency check'i yoksa aktive olmaz).

### wp-cli helper iki modlu

[\`helpers/wp-cli.ts\`](tests/e2e/helpers/wp-cli.ts) — env var \`HEZARFEN_E2E_USE_WP_ENV=1\` ile mod değişiyor:
- **LocalWP modu (default):** mevcut ssh-entry script PATH'i ile lokal \`wp\` binary'sini çağırıyor
- **wp-env modu:** \`node_modules/.bin/wp-env run cli -- wp …\` (npx aradan çıkarıldı; npm script banner'ları stdout'u kirletiyordu)

### global-setup'a fresh-install bootstrap'ları

LocalWP'de elle/zaman içinde kurulu olan ama wp-env'de \"sıfırdan\" eksik kalan ne varsa programatik olarak seed ediliyor:

- \`WC_Install::create_pages()\` — Cart/Checkout/My Account/Shop sayfaları
- Pretty permalinks + \`.htaccess\` yazımı (cli container yazamadığı için PHP runtime üzerinden)
- **Hezarfen encryption key** — \`HEZARFEN_ENCRYPTION_KEY\` constant'ı + \`hezarfen_encryption_key_generated\` option + \`Istanbul\` tester ciphertext. Bu olmadan \`PostMetaEncryption::health_check()\` false dönüyor ve TC alanı hiç render olmuyor.
- **MSS / Ön Bilgilendirme contracts seed** — \`hezarfen_mss_settings\` option'ı combined-checkbox layout ile iki sözleşme.
- **HPOS enable** — \`wc_allow_changing_orders_storage_while_sync_is_pending\` filter'ı geçici açılarak option'lar yazılıyor (HPOS olmadan \`/wp-admin/admin.php?page=wc-orders\` URL'i yok ve admin-order-edit testleri 404).

PHP escape savaşından kaçınmak için iki bootstrap fixture eklendi (\`tests/e2e/fixtures/enable-hpos.php\` + \`seed-encryption-tester.php\`); \`wp eval-file\` ile çağrılıyorlar.

### Test düzeltmeleri (env-fark)

- **\`fillTrAddressChain\`** artık AJAX response sonrası options'ın DOM'a iliştirildiğini bekliyor (\`waitForOptionsPopulated\`). Hızlı LocalWP'de yarış kazanılıyordu, yavaş wp-env'de değil.
- **\`checkout-shipping-address.spec.ts\`** — sabit Kadıköy mahallesi (\"19 Mayıs Mah\") seçiyor, ilk-non-placeholder dinamiği kaldırıldı.
- **\`admin-shipment-tracking.spec.ts\`** — \`#hezarfen-lite-tab\` assertion'ı kaldırıldı (Pro varsa render olur, CI'da Pro yok).

## Sonuç

\`\`\`
20 passed, 1 skipped (~2.5m wp-env)
20 passed, 1 skipped (~1.7m LocalWP)
\`\`\`

Aynı suite her iki ortamda da yeşil. Ortam farklarını TS/PHP fixture katmanı kapatıyor.

## Test plan
- [ ] PR açılınca \`E2E (Playwright)\` workflow'u tetikleniyor ve geçiyor
- [ ] HTML report artifact (\`playwright-report\`) PR sayfasından indirilebiliyor
- [ ] \`HEZARFEN_E2E_USE_WP_ENV=1 npx playwright test\` lokalde de çalışıyor (Docker varsa)
- [ ] LocalWP'de \`npm run test:e2e:playwright\` (env var olmadan) hâlâ yeşil

## Bonus

CI tarafı; release/deploy workflow'larından bağımsız. Branch koruması yoksa eklemek isteyebilirsin: \"Require status check 'E2E (Playwright)' to pass before merging\".

Lokalimde hâlâ test breakage için kullandığımız \`wp-content/mu-plugins/hezarfen-e2e-break.php\` duruyor — wp-env CI'a etki etmiyor (ayrı ortam) ama LocalWP testlerini hâlâ kırıyor; bittiyse \`rm\` edebilirsin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)