### PR TITLE
ci: restore e2e auto-triggers on develop push and PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,16 @@
 name: E2E (Playwright)
 
 on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    # `develop` keeps the dev-feedback path; adding `master` makes the
+    # check appear on Release PRs (develop → master) so branch
+    # protection on master can require it.
+    branches:
+      - develop
+      - master
   workflow_dispatch:
 
 concurrency:

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -20,10 +20,29 @@ export async function loginAsCustomer( page: Page ): Promise< void > {
 }
 
 export async function loginAsAdmin( page: Page ): Promise< void > {
-	await page.goto( '/wp-login.php' );
-	await page.locator( '#user_login' ).fill( E2E_ADMIN.username );
-	await page.locator( '#user_pass' ).fill( E2E_ADMIN.password );
-	await page.locator( '#wp-submit' ).click();
-	await page.waitForURL( /wp-admin/, { timeout: 15_000 } );
+	// On wp-env cold-starts (first test in a worker), `wp-login.php`'s
+	// show-password JS can mutate `#user_pass` after we've already
+	// resolved a locator for it — the fill then lands on whatever input
+	// still has focus (typically `#user_login`), and the submit is
+	// rejected by the browser's native required-field validator.
+	// Waiting for both inputs to be attached + clicking before fill
+	// pins focus to the right element, and Promise.all on submit avoids
+	// the race where waitForURL is registered after the redirect already
+	// fired.
+	await page.goto( '/wp-login.php', { waitUntil: 'domcontentloaded' } );
+	const userInput = page.locator( '#user_login' );
+	const passInput = page.locator( '#user_pass' );
+	await userInput.waitFor( { state: 'visible' } );
+	await passInput.waitFor( { state: 'visible' } );
+
+	await userInput.click();
+	await userInput.fill( E2E_ADMIN.username );
+	await passInput.click();
+	await passInput.fill( E2E_ADMIN.password );
+
+	await Promise.all( [
+		page.waitForURL( /wp-admin/, { timeout: 30_000 } ),
+		page.locator( '#wp-submit' ).click(),
+	] );
 	await expect( page.locator( '#wpadminbar' ) ).toBeVisible();
 }


### PR DESCRIPTION
## Summary
- Restores `push: develop` and `pull_request: [develop, master]` triggers on `e2e.yml` (reverts the e2e portion of 9c98b0b which left it as `workflow_dispatch`-only).
- Without this, develop pushes don't run Playwright and PRs into develop have no e2e gate (the check can't be required by branch protection because it never appears on PRs).

## Test plan
- [ ] After merge: confirm the workflow runs on next push to `develop`.
- [ ] Open a throwaway PR into `develop` and confirm the `playwright` check appears.
- [ ] Then add `playwright` to develop's required status checks in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)