### PR TITLE
fix(readme): plugin başlığından "WooCommerce Kargo Entegrasyonu" kaldırıldı

### DIFF
--- a/hezarfen-for-woocommerce.php
+++ b/hezarfen-for-woocommerce.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Kargo Takip, WooCommerce Kargo Entegrasyonu, SMS, Mesafeli Sözleşme – Hezarfen
+ * Plugin Name: Kargo Takip, Kargo SMS, İlçe Mahalle Sözleşme by Hezarfen
  * Description: WooCommerce kargo takip ve kargo entegrasyon eklentisi. 26+ kargo firması: kargo barkod oluşturma, kargo durum sorgulama, kargo SMS ve e-posta bildirimleri. Ücretsiz Hepsijet kargo entegrasyonu. İlçe/mahalle seçimi, mesafeli satış sözleşmesi, ön bilgilendirme formu, e-fatura alanları.
  * Version: 2.11.1
  * Author: Intense Yazılım Ltd.

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 
-=== Kargo Takip, WooCommerce Kargo Entegrasyonu, SMS, Mesafeli Sözleşme – Hezarfen ===
+=== Kargo Takip, Kargo SMS, İlçe Mahalle Sözleşme by Hezarfen ===
 Contributors: intenseyazilim, mucahitbal, mskapusuz
 Tags: kargo, kargo takip, kargo entegrasyonu, yurtiçi kargo, aras kargo
 Requires at least: 5.3


### PR DESCRIPTION
## Özet

- WP.org'da yayında olan 2.11.1 sürümünün başlığında **"WooCommerce Kargo Entegrasyonu"** ifadesi geçiyor. Bu kullanım WooCommerce trademark politikasına aykırı (marka, eklenti adında tanımlayıcı olmayan biçimde kullanılamaz).
- Başlık, develop branch'inde halen duran onaylı sürüme geri çevrildi: **"Kargo Takip, Kargo SMS, İlçe Mahalle Sözleşme by Hezarfen"**.
- Değişiklik iki yerde: `readme.txt` ilk satır + `hezarfen-for-woocommerce.php` `Plugin Name` header.
- Version / Stable tag'e dokunulmadı (2.11.1 olarak kalıyor) — WP.org'a yansıması için ayrı bir release bump'ı (örn. 2.11.2) gerekecek.

## Arka plan

`e97d993 readme: başlık güncellendi` commit'i master'a doğrudan yazılıp 2.11.1 olarak yayınlanmış; develop'a bu değişiklik gitmemişti. Develop'taki başlık zaten doğru.

## Test planı

- [ ] readme.txt ilk satırının yeni başlığı yansıttığını doğrula
- [ ] `hezarfen-for-woocommerce.php` `Plugin Name` header'ının yeni başlığı yansıttığını doğrula
- [ ] Merge sonrası 2.11.2 hotfix release açıldığında WP.org plugin sayfası başlığının güncellendiğini kontrol et (cache 6-24 saat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)