### PR TITLE
fix(readme): plugin başlığı tekrar düzeltildi ("WooCommerce Kargo Entegrasyonu" trademark)

### DIFF
--- a/hezarfen-for-woocommerce.php
+++ b/hezarfen-for-woocommerce.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Kargo Takip, WooCommerce Kargo Entegrasyonu, SMS, Mesafeli Sözleşme – Hezarfen
+ * Plugin Name: Kargo Takip, Kargo SMS, İlçe Mahalle Sözleşme by Hezarfen
  * Description: WooCommerce kargo takip ve kargo entegrasyon eklentisi. 26+ kargo firması: kargo barkod oluşturma, kargo durum sorgulama, kargo SMS ve e-posta bildirimleri. Ücretsiz Hepsijet kargo entegrasyonu. İlçe/mahalle seçimi, mesafeli satış sözleşmesi, ön bilgilendirme formu, e-fatura alanları.
  * Version: 2.11.2
  * Author: Intense Yazılım Ltd.

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 
-=== Kargo Takip, WooCommerce Kargo Entegrasyonu, SMS, Mesafeli Sözleşme – Hezarfen ===
+=== Kargo Takip, Kargo SMS, İlçe Mahalle Sözleşme by Hezarfen ===
 Contributors: intenseyazilim, mucahitbal, mskapusuz
 Tags: kargo, kargo takip, kargo entegrasyonu, yurtiçi kargo, aras kargo
 Requires at least: 5.3


### PR DESCRIPTION
## Özet

PR #156 (Revert "fix(readme)…") commit'inin revert'idir. Plugin başlığını **"Kargo Takip, Kargo SMS, İlçe Mahalle Sözleşme by Hezarfen"** olarak geri getirir.

### Neden gerekli?

- WP.org'da 2.11.1 sürümü **"Kargo Takip, WooCommerce Kargo Entegrasyonu, SMS, Mesafeli Sözleşme – Hezarfen"** başlığıyla yayında.
- **"WooCommerce Kargo Entegrasyonu"** ifadesi WooCommerce trademark politikasına aykırı (marka, eklenti adında tanımlayıcı olmayan biçimde kullanılamaz). WP.org tarafından kaldırılma riski var.
- Mevcut master HEAD halen eski başlığı içeriyor; release 2.11.2 master'dan deploy edilirse yine yanlış başlık çıkacak.

### Tarihçe

- PR #155 (master) — başlığı düzeltti (`390c501`). Merge oldu.
- PR #156 (master) — bu düzeltmeyi revert etti (`2745e40`). 
- PR #157 (develop) — aynı düzeltme develop'a girdi. Develop halen doğru başlığı içeriyor ✅
- PR #158 (develop→master) merge'inde master'daki revert kazandı; başlık master'da yine eski hale döndü ❌

### Değişiklik

- `readme.txt` ilk satır
- `hezarfen-for-woocommerce.php` `Plugin Name` header

Version/Stable tag'e dokunulmadı (2.11.2 olarak kalıyor).

## Test planı

- [ ] `readme.txt` ilk satırı ve `Plugin Name` header'ın yeni başlığı yansıttığını doğrula
- [ ] Bu PR neden açıldı? — PR #156 yanlışlıkla / haberi olmadan açılmış olabilir; merge'den önce ekipten teyit al
- [ ] Merge sonrası 2.11.2 release'in başlığı doğru çıkmalı (WP.org cache 6-24 saat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)