### PR TITLE
ci(pr-build): her commit'te otomatik zip build + sticky yorum

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,50 +1,87 @@
-name: PR build
+name: PR Build
+
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [develop, master]
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
+    if: >-
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-build')
     runs-on: ubuntu-latest
     steps:
-      - name: Get current time
-        uses: josStorer/get-current-time@v2
-        id: current-time
+      - name: Checkout PR head
+        uses: actions/checkout@v4
         with:
-          format: YYYYMMDD-HHmmss
-          utcOffset: "+03:00"
-      - uses: actions/checkout@v2
-      - name: Install WP CLI
-        run: | 
-          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-          php wp-cli.phar --info
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Install Composer dependencies (production)
+        run: composer install -o --no-dev --no-progress
+
+      - name: Install WP-CLI + dist-archive
+        run: |
+          curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
           chmod +x wp-cli.phar
           sudo mv wp-cli.phar /usr/local/bin/wp
-      - name: Install WP Dist Archive
-        run: wp package install wp-cli/dist-archive-command:@stable
-      - name: Create Dist Package
-        run: wp dist-archive . dist.zip
-      - uses: montudor/action-zip@v1
+          wp package install wp-cli/dist-archive-command:@stable
+
+      - name: Compute build metadata
+        id: meta
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          VERSION=$(grep -E '^[[:space:]]*\*[[:space:]]*Version:' hezarfen-for-woocommerce.php | head -1 | sed -E 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')
+          SHORT_SHA=${HEAD_SHA::7}
+          ZIP_NAME="hezarfen-for-woocommerce-pr${PR_NUMBER}-${SHORT_SHA}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Build dist zip
+        env:
+          ZIP_NAME: ${{ steps.meta.outputs.zip_name }}
+        run: |
+          wp dist-archive . "${ZIP_NAME}.zip"
+          ls -lh "${ZIP_NAME}.zip"
+
+      - name: Upload artifact
+        id: upload
+        uses: actions/upload-artifact@v4
         with:
-          args: unzip -qq dist.zip -d dist-plugin-package
-      - uses: actions/upload-artifact@v2
+          name: ${{ steps.meta.outputs.zip_name }}
+          path: ${{ steps.meta.outputs.zip_name }}.zip
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Post or update sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          name: ${{ github.event.repository.name }}-build-pr#${{ github.event.pull_request.number }}-${{ steps.current-time.outputs.formattedTime }}
-          path: dist-plugin-package
-          retention-days: 3
-  comment:
-    needs: [build]
-    if: "${{ github.event.label.name == 'command: build' }}"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mshick/add-pr-comment@v1
-        with:
+          header: pr-build
           message: |
-            Build package is ready!
-            [Download build package](https://github.com/intensesoftware/${{ github.event.repository.name }}/actions/runs/${{github.run_id}})
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: true # This is the default
-      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: |
-            command: build
+            ## Test build hazır
+
+            **Sürüm:** `v${{ steps.meta.outputs.version }}` · **Commit:** [`${{ steps.meta.outputs.short_sha }}`](${{ github.event.pull_request.head.repo.html_url }}/commit/${{ github.event.pull_request.head.sha }}) · **Run:** [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            **İndirme:**
+            - [Artifact sayfası (GitHub login gerekir)](${{ steps.upload.outputs.artifact-url }})
+            - [Direkt zip (nightly.link, login gerektirmez)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/${{ steps.meta.outputs.zip_name }}.zip)
+
+            > İndirilen wrapper zip'i bir kez aç → içindeki `${{ steps.meta.outputs.zip_name }}.zip` dosyasını WordPress > Eklentiler > Yeni Ekle > Eklenti Yükle ile kurabilirsin.
+            >
+            > Bu yorum her yeni commit'te güncellenir. Build istemiyorsan PR'a `skip-build` label'ı ekle.

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Install Composer dependencies (production)
         run: composer install -o --no-dev --no-progress
 
-      - name: Install WP-CLI + dist-archive
-        run: |
-          curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-          chmod +x wp-cli.phar
-          sudo mv wp-cli.phar /usr/local/bin/wp
-          wp package install wp-cli/dist-archive-command:@stable
-
       - name: Compute build metadata
         id: meta
         env:
@@ -57,8 +50,13 @@ jobs:
         env:
           ZIP_NAME: ${{ steps.meta.outputs.zip_name }}
         run: |
-          wp dist-archive . "${ZIP_NAME}.zip"
+          PACKAGE_DIR=$(mktemp -d)
+          mkdir -p "$PACKAGE_DIR/hezarfen-for-woocommerce"
+          rsync -a --exclude-from=.distignore ./ "$PACKAGE_DIR/hezarfen-for-woocommerce/"
+          (cd "$PACKAGE_DIR" && zip -rq "${GITHUB_WORKSPACE}/${ZIP_NAME}.zip" hezarfen-for-woocommerce)
           ls -lh "${ZIP_NAME}.zip"
+          echo "--- top-level entries in zip ---"
+          unzip -l "${ZIP_NAME}.zip" | head -20
 
       - name: Upload artifact
         id: upload


### PR DESCRIPTION
## Özet

`pr-build.yml` workflow'u baştan yazıldı. Önceki workflow:

- Sadece manuel `command: build` label'ı eklenince çalışıyordu.
- `composer install` çalıştırmadığı için **TCPDF dahil production dependency'leri zip'e dahil edilmiyordu** — kurulduğunda eklenti çalışmıyordu (Hepsijet etiket / contract PDF üretimi vs. patlardı).
- `actions/checkout@v2`, `actions/upload-artifact@v2`, `mshick/add-pr-comment@v1` gibi deprecated action sürümlerini kullanıyordu.
- Artifact'i unzip'li klasör olarak yüklediği için kullanıcı tekrar zip'lemeden WP eklenti yükleyicisine veremiyordu.

## Yeni davranış

- **Trigger:** PR açıldığında / her yeni commit'te / reopen / ready-for-review (develop ve master base'leri için).
- **Build:** `composer install -o --no-dev` → `wp dist-archive` → `hezarfen-for-woocommerce-pr<NUM>-<sha7>.zip` (WP eklenti yükleyicisinin doğrudan kabul ettiği format).
- **Artifact:** 14 gün tutulur, ismi PR# + short SHA içerir.
- **Yorum:** `marocchino/sticky-pull-request-comment` ile PR'a **tek bir sticky yorum** bırakılır; her yeni commit'te aynı yorum güncellenir, spam olmaz. İçinde:
  - GitHub artifact sayfası linki (GH login gerekir)
  - `nightly.link` üzerinden login'siz direkt zip indirme linki
  - Workflow run linki
- **Concurrency:** Aynı PR'da yeni commit gelince eski koşan build iptal edilir.
- **Opt-out:** Draft PR veya `skip-build` label'ı varsa job atlanır.

## Test planı

- [ ] Bu PR'ın kendisinde sticky yorum görünüyor ve nightly.link linki çalışıyor mu
- [ ] İndirilen wrapper zip'i bir kez açınca `hezarfen-for-woocommerce-prN-sha.zip` çıkıyor ve WP > Eklentiler > Yeni Ekle > Eklenti Yükle ile sorunsuz kuruluyor mu
- [ ] Kurulan eklentide TCPDF'e bağlı özellikler (Hepsijet etiket PDF, MST sözleşme PDF) çalışıyor mu — vendor klasörü zip içinde olmalı
- [ ] PR'a yeni commit pushlayınca yorum güncelleniyor mu (yeni yorum açılmıyor)
- [ ] `skip-build` label'ı eklenince yeni commit'te build çalışmıyor mu