### PR TITLE
fix(checkout): İlçe/Mahalle alanları ADP ile boş geliyor (erken get_checkout_fields yarışı)

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -46,9 +46,20 @@ class Checkout {
 			add_action( 'wp', array( $this, 'hide_postcode_fields' ) );
 		}
 
-		// TODO: review the logic, if it's possible; define all fields in a single function.
-		// Register district/neighborhood fields on init to allow other plugins to filter
-		add_action( 'wp', array( $this, 'register_district_neighborhood_fields' ) );
+		// Register the district/neighborhood (and related TR address) checkout
+		// field filters as early as possible — at construction time.
+		//
+		// WC_Checkout::get_checkout_fields() memoizes its result and can be
+		// triggered any time after `init` by the Store API, blocks, or
+		// third-party plugins (e.g. Advanced Dynamic Pricing computing cart
+		// totals on `wp_loaded`). Registering on the later `wp` hook meant such
+		// an early build locked in WooCommerce's default fields before our
+		// filters ran, so the İlçe / Mahalle selects were never applied.
+		//
+		// The enable-option is now evaluated at runtime inside the callbacks
+		// (see is_district_neighborhood_enabled()) so other plugins can still
+		// filter it.
+		$this->register_district_neighborhood_fields();
 
 		add_filter(
 			'woocommerce_checkout_posted_data',
@@ -90,18 +101,18 @@ class Checkout {
 	}
 
 	/**
-	 * Register district and neighborhood fields hooks.
-	 * Called on 'init' hook to allow other plugins/themes to filter the enable option.
+	 * Register district and neighborhood field hooks.
+	 *
+	 * Filters are attached unconditionally here (from the constructor) so they
+	 * are in place before any early WC_Checkout::get_checkout_fields() build.
+	 * Whether they actually modify the fields is decided at runtime by
+	 * is_district_neighborhood_enabled(), which keeps the
+	 * `hezarfen_enable_district_neighborhood_fields` filter overridable by
+	 * other plugins.
 	 *
 	 * @return void
 	 */
 	public function register_district_neighborhood_fields() {
-		$enable_district_neighborhood = apply_filters( 'hezarfen_enable_district_neighborhood_fields', get_option( 'hezarfen_enable_district_neighborhood_fields', 'yes' ) );
-		
-		if ( 'yes' !== $enable_district_neighborhood ) {
-			return;
-		}
-
 		add_filter(
 			'woocommerce_checkout_fields',
 			array(
@@ -130,6 +141,22 @@ class Checkout {
 				$this,
 				'make_visible_address2_label',
 			),
+		);
+	}
+
+	/**
+	 * Whether the TR district/neighborhood checkout fields are enabled.
+	 *
+	 * Evaluated at runtime (when the filters fire) rather than at registration
+	 * time so the `hezarfen_enable_district_neighborhood_fields` filter can be
+	 * set by any plugin/theme that loads after this class.
+	 *
+	 * @return bool
+	 */
+	private function is_district_neighborhood_enabled() {
+		return 'yes' === apply_filters(
+			'hezarfen_enable_district_neighborhood_fields',
+			get_option( 'hezarfen_enable_district_neighborhood_fields', 'yes' )
 		);
 	}
 
@@ -170,6 +197,10 @@ class Checkout {
 	 * @return array
 	 */
 	public function update_address_2_fields_for_tr( $country_locale_settings ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $country_locale_settings;
+		}
+
 		if ( ! array_key_exists( 'TR', $country_locale_settings ) ) {
 			return $country_locale_settings;
 		}
@@ -189,6 +220,10 @@ class Checkout {
 	 * @return array<string, mixed>
 	 */
 	public function make_visible_address2_label( $fields ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $fields;
+		}
+
 		// Check if address_2 field exists and has label_class
 		if ( ! isset( $fields['address_2'] ) || ! isset( $fields['address_2']['label_class'] ) ) {
 			return $fields;
@@ -210,6 +245,10 @@ class Checkout {
 	 * @return array<string, mixed>
 	 */
 	public function make_address2_required_and_update_the_label( $fields ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $fields;
+		}
+
 		// Check if billing address_2 field exists before modifying it
 		if ( isset( $fields['billing']['billing_address_2'] ) ) {
 			$fields['billing']['billing_address_2']['required']      = true;
@@ -503,6 +542,10 @@ class Checkout {
 	 * @return array<string, mixed>
 	 */
 	public function add_district_and_neighborhood_fields( $fields ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $fields;
+		}
+
 		$types = array( 'shipping', 'billing' );
 
 		global $woocommerce;

--- a/tests/e2e/checkout-adp-field-race.spec.ts
+++ b/tests/e2e/checkout-adp-field-race.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test';
+import {
+	addE2EProductToCart,
+	expectMahalleAjax,
+	pickFromSelect,
+	waitForCheckoutIdle,
+	TR_SAMPLE_ADDRESS,
+} from './helpers/checkout';
+import { deleteMuPlugin, writeMuPlugin } from './helpers/mu-plugin';
+import { wp } from './helpers/wp-cli';
+
+/**
+ * Regression: Hezarfen ↔ early checkout-fields build race.
+ *
+ * Reproduces the Advanced Dynamic Pricing (ADP) interaction reported in
+ * production. ADP processes the cart on the `wp_loaded` hook:
+ *
+ *   Engine::firstTimeProcessCart → CartProcessor::process →
+ *   WC_Cart_Totals → WC_Cart::calculate_shipping →
+ *   WC_Cart::show_shipping → WC_Checkout::get_checkout_fields()
+ *
+ * That call makes WooCommerce build AND memoize the checkout field
+ * definitions. Hezarfen registers its TR district/neighborhood field
+ * transformation on the *later* `wp` hook, so by the time it runs the field
+ * set is already cached and the İlçe (#billing_city) / Mahalle
+ * (#billing_address_1) selects are never applied — they stay plain inputs.
+ *
+ * Only guests are affected (logged-in carts are not processed the same way
+ * on `wp_loaded`), which matches the "broken in incognito, fine when logged
+ * in as admin" report.
+ *
+ * The early `get_checkout_fields()` side effect is triggered deterministically
+ * via a tiny fixture mu-plugin rather than by configuring an ADP pricing rule:
+ * the mechanism — and therefore the regression guard — is identical and
+ * version-independent. (Activating ADP alone does not reproduce it; ADP only
+ * processes the cart when at least one pricing rule is enabled.)
+ *
+ * Expected: FAILS against current code (İlçe renders as <input>), PASSES once
+ * Hezarfen registers its checkout-field filters before `wp_loaded`
+ * (e.g. in the constructor or on `init` instead of `wp`).
+ */
+const FIXTURE_SLUG = 'hezarfen-e2e-early-checkout-fields';
+const FIXTURE_OPTION = 'hezarfen_e2e_force_early_checkout_fields';
+
+const FIXTURE_PHP = `<?php
+/**
+ * E2E fixture: emulate a plugin (e.g. Advanced Dynamic Pricing) that processes
+ * the cart on wp_loaded and forces WC_Checkout::get_checkout_fields() to build
+ * + memoize before Hezarfen's 'wp' hook runs. Inert unless the gating option is
+ * set to 'yes'.
+ */
+add_action( 'wp_loaded', function () {
+	if ( is_admin() ) {
+		return;
+	}
+	if ( get_option( '${ FIXTURE_OPTION }' ) !== 'yes' ) {
+		return;
+	}
+	if ( function_exists( 'WC' ) && WC()->checkout() ) {
+		WC()->checkout()->get_checkout_fields();
+	}
+}, 5 );
+`;
+
+test.describe( 'Hezarfen checkout field race (ADP-style early build)', () => {
+	test.beforeAll( () => {
+		writeMuPlugin( FIXTURE_SLUG, FIXTURE_PHP );
+		wp( [ 'option', 'update', FIXTURE_OPTION, 'yes' ] );
+	} );
+
+	test.afterAll( () => {
+		wp( [ 'option', 'delete', FIXTURE_OPTION ], { allowFailure: true } );
+		deleteMuPlugin( FIXTURE_SLUG );
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'İlçe stays a Hezarfen select dropdown despite an early get_checkout_fields() (guest)', async ( {
+		page,
+	} ) => {
+		await page.goto( '/checkout/' );
+		await waitForCheckoutIdle( page );
+
+		await expect( page.locator( '#billing_country' ) ).toHaveValue( 'TR' );
+
+		// The bug: the early get_checkout_fields() locks in WooCommerce's
+		// default text input for billing_city, so Hezarfen never turns it into
+		// the il-driven district <select>.
+		await expect( page.locator( 'select#billing_city' ) ).toBeAttached();
+		await expect( page.locator( 'input#billing_city' ) ).toHaveCount( 0 );
+
+		// And it must still work end-to-end: picking the il triggers the
+		// district AJAX and populates İlçe options.
+		const districtPromise = expectMahalleAjax( page, 'district' );
+		await pickFromSelect(
+			page,
+			'#billing_state',
+			TR_SAMPLE_ADDRESS.cityPlate
+		);
+		await districtPromise;
+
+		const districts = await page
+			.locator( '#billing_city option' )
+			.allTextContents();
+		expect( districts ).toContain( TR_SAMPLE_ADDRESS.district );
+	} );
+} );


### PR DESCRIPTION
## Sorun

Misafir (logout) kullanıcılarda checkout'ta **İlçe (`#billing_city`) ve Mahalle (`#billing_address_1`) alanları Hezarfen dropdown'u yerine düz `<input>` olarak geliyor.** Giriş yapmış kullanıcılarda sorun yok — bu yüzden "normal tarayıcıda çalışıyor, gizli sekmede boş" şeklinde rapor edildi.

## Kök neden

`WC_Checkout::get_checkout_fields()` sonucunu **memoize eder** ve `init`'ten sonra herhangi bir şey (Store API, bloklar, üçüncü-parti eklentiler) tarafından tetiklenebilir. **Advanced Dynamic Pricing (ADP)** sepet toplamlarını `wp_loaded`'da hesaplıyor:

```
ADP Engine::firstTimeProcessCart → CartProcessor → WC_Cart_Totals
→ WC_Cart::calculate_shipping → WC_Cart::show_shipping
→ WC_Checkout::get_checkout_fields()
```

Bu erken çağrı, WooCommerce'in varsayılan alanlarını **kilitliyor**. Hezarfen ise district/neighborhood dönüşümünü daha **geç** olan `wp` hook'unda kaydediyordu — bu yüzden filtre devreye girdiğinde alanlar zaten önbelleğe alınmış oluyor ve İlçe/Mahalle select'leri hiç uygulanmıyordu.

Sadece misafirleri etkiliyor çünkü ADP sepeti misafir oturumunda `wp_loaded`'da işliyor.

> Bu ADP'ye özel değil: `init`/`wp_loaded`'da checkout alanlarını erken tetikleyen **herhangi** bir eklenti aynı sorunu yaratır. Asıl kusur, Hezarfen'in filtreyi WooCommerce konvansiyonundan daha geç kaydetmesi.

## Çözüm

- Checkout alan filtrelerini `wp` yerine **constructor'da** (mümkün olan en erken) kaydet.
- `hezarfen_enable_district_neighborhood_fields` kontrolünü **runtime'a** taşı (yeni `is_district_neighborhood_enabled()`), böylece opsiyon hâlâ filtrelenebilir ama filtreler herhangi bir erken `get_checkout_fields()` build'inden önce bağlı oluyor.
- İlgili dört callback'e runtime guard eklendi.

## Doğrulama

Local mağazada gerçek tarayıcıyla:

| Durum | İlçe |
|---|---|
| Fix öncesi + erken build (ADP davranışı) | ❌ INPUT |
| Fix sonrası + erken build | ✅ SELECT |
| Fix sonrası + normal | ✅ SELECT |

## Test

`tests/e2e/checkout-adp-field-race.spec.ts` — ADP'nin erken `get_checkout_fields()` yan etkisini deterministik (gated fixture mu-plugin) olarak reprodüce eden regression testi. Fix'ten önce fail, fix'ten sonra pass.

## Takip (bu PR kapsamı dışı)

`hide_postcode_fields` aynı gecikmeli-kayıt desenini hâlâ `wp` hook'unda kullanıyor; aynı zafiyete açık. Bu PR'ı odaklı tutmak için dahil edilmedi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)