### PR TITLE
fix(checkout): İlçe/Mahalle alanları ADP ile boş geliyor (erken get_checkout_fields yarışı)

### DIFF
--- a/includes/Checkout.php
+++ b/includes/Checkout.php
@@ -46,9 +46,20 @@ class Checkout {
 			add_action( 'wp', array( $this, 'hide_postcode_fields' ) );
 		}
 
-		// TODO: review the logic, if it's possible; define all fields in a single function.
-		// Register district/neighborhood fields on init to allow other plugins to filter
-		add_action( 'wp', array( $this, 'register_district_neighborhood_fields' ) );
+		// Register the district/neighborhood (and related TR address) checkout
+		// field filters as early as possible — at construction time.
+		//
+		// WC_Checkout::get_checkout_fields() memoizes its result and can be
+		// triggered any time after `init` by the Store API, blocks, or
+		// third-party plugins (e.g. Advanced Dynamic Pricing computing cart
+		// totals on `wp_loaded`). Registering on the later `wp` hook meant such
+		// an early build locked in WooCommerce's default fields before our
+		// filters ran, so the İlçe / Mahalle selects were never applied.
+		//
+		// The enable-option is now evaluated at runtime inside the callbacks
+		// (see is_district_neighborhood_enabled()) so other plugins can still
+		// filter it.
+		$this->register_district_neighborhood_fields();
 
 		add_filter(
 			'woocommerce_checkout_posted_data',
@@ -90,18 +101,18 @@ class Checkout {
 	}
 
 	/**
-	 * Register district and neighborhood fields hooks.
-	 * Called on 'init' hook to allow other plugins/themes to filter the enable option.
+	 * Register district and neighborhood field hooks.
+	 *
+	 * Filters are attached unconditionally here (from the constructor) so they
+	 * are in place before any early WC_Checkout::get_checkout_fields() build.
+	 * Whether they actually modify the fields is decided at runtime by
+	 * is_district_neighborhood_enabled(), which keeps the
+	 * `hezarfen_enable_district_neighborhood_fields` filter overridable by
+	 * other plugins.
 	 *
 	 * @return void
 	 */
 	public function register_district_neighborhood_fields() {
-		$enable_district_neighborhood = apply_filters( 'hezarfen_enable_district_neighborhood_fields', get_option( 'hezarfen_enable_district_neighborhood_fields', 'yes' ) );
-		
-		if ( 'yes' !== $enable_district_neighborhood ) {
-			return;
-		}
-
 		add_filter(
 			'woocommerce_checkout_fields',
 			array(
@@ -130,6 +141,22 @@ class Checkout {
 				$this,
 				'make_visible_address2_label',
 			),
+		);
+	}
+
+	/**
+	 * Whether the TR district/neighborhood checkout fields are enabled.
+	 *
+	 * Evaluated at runtime (when the filters fire) rather than at registration
+	 * time so the `hezarfen_enable_district_neighborhood_fields` filter can be
+	 * set by any plugin/theme that loads after this class.
+	 *
+	 * @return bool
+	 */
+	private function is_district_neighborhood_enabled() {
+		return 'yes' === apply_filters(
+			'hezarfen_enable_district_neighborhood_fields',
+			get_option( 'hezarfen_enable_district_neighborhood_fields', 'yes' )
 		);
 	}
 
@@ -170,6 +197,10 @@ class Checkout {
 	 * @return array
 	 */
 	public function update_address_2_fields_for_tr( $country_locale_settings ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $country_locale_settings;
+		}
+
 		if ( ! array_key_exists( 'TR', $country_locale_settings ) ) {
 			return $country_locale_settings;
 		}
@@ -189,6 +220,10 @@ class Checkout {
 	 * @return array<string, mixed>
 	 */
 	public function make_visible_address2_label( $fields ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $fields;
+		}
+
 		// Check if address_2 field exists and has label_class
 		if ( ! isset( $fields['address_2'] ) || ! isset( $fields['address_2']['label_class'] ) ) {
 			return $fields;
@@ -210,6 +245,10 @@ class Checkout {
 	 * @return array<string, mixed>
 	 */
 	public function make_address2_required_and_update_the_label( $fields ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $fields;
+		}
+
 		// Check if billing address_2 field exists before modifying it
 		if ( isset( $fields['billing']['billing_address_2'] ) ) {
 			$fields['billing']['billing_address_2']['required']      = true;
@@ -503,6 +542,10 @@ class Checkout {
 	 * @return array<string, mixed>
 	 */
 	public function add_district_and_neighborhood_fields( $fields ) {
+		if ( ! $this->is_district_neighborhood_enabled() ) {
+			return $fields;
+		}
+
 		$types = array( 'shipping', 'billing' );
 
 		global $woocommerce;

--- a/tests/e2e/checkout-adp-field-race.spec.ts
+++ b/tests/e2e/checkout-adp-field-race.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test';
+import {
+	addE2EProductToCart,
+	expectMahalleAjax,
+	pickFromSelect,
+	waitForCheckoutIdle,
+	TR_SAMPLE_ADDRESS,
+} from './helpers/checkout';
+import { deleteMuPlugin, writeMuPlugin } from './helpers/mu-plugin';
+import { wp } from './helpers/wp-cli';
+
+/**
+ * Regression: Hezarfen ↔ early checkout-fields build race.
+ *
+ * Reproduces the Advanced Dynamic Pricing (ADP) interaction reported in
+ * production. ADP processes the cart on the `wp_loaded` hook:
+ *
+ *   Engine::firstTimeProcessCart → CartProcessor::process →
+ *   WC_Cart_Totals → WC_Cart::calculate_shipping →
+ *   WC_Cart::show_shipping → WC_Checkout::get_checkout_fields()
+ *
+ * That call makes WooCommerce build AND memoize the checkout field
+ * definitions. Hezarfen registers its TR district/neighborhood field
+ * transformation on the *later* `wp` hook, so by the time it runs the field
+ * set is already cached and the İlçe (#billing_city) / Mahalle
+ * (#billing_address_1) selects are never applied — they stay plain inputs.
+ *
+ * Only guests are affected (logged-in carts are not processed the same way
+ * on `wp_loaded`), which matches the "broken in incognito, fine when logged
+ * in as admin" report.
+ *
+ * The early `get_checkout_fields()` side effect is triggered deterministically
+ * via a tiny fixture mu-plugin rather than by configuring an ADP pricing rule:
+ * the mechanism — and therefore the regression guard — is identical and
+ * version-independent. (Activating ADP alone does not reproduce it; ADP only
+ * processes the cart when at least one pricing rule is enabled.)
+ *
+ * Expected: FAILS against current code (İlçe renders as <input>), PASSES once
+ * Hezarfen registers its checkout-field filters before `wp_loaded`
+ * (e.g. in the constructor or on `init` instead of `wp`).
+ */
+const FIXTURE_SLUG = 'hezarfen-e2e-early-checkout-fields';
+const FIXTURE_OPTION = 'hezarfen_e2e_force_early_checkout_fields';
+
+const FIXTURE_PHP = `<?php
+/**
+ * E2E fixture: emulate a plugin (e.g. Advanced Dynamic Pricing) that processes
+ * the cart on wp_loaded and forces WC_Checkout::get_checkout_fields() to build
+ * + memoize before Hezarfen's 'wp' hook runs. Inert unless the gating option is
+ * set to 'yes'.
+ */
+add_action( 'wp_loaded', function () {
+	if ( is_admin() ) {
+		return;
+	}
+	if ( get_option( '${ FIXTURE_OPTION }' ) !== 'yes' ) {
+		return;
+	}
+	if ( function_exists( 'WC' ) && WC()->checkout() ) {
+		WC()->checkout()->get_checkout_fields();
+	}
+}, 5 );
+`;
+
+test.describe( 'Hezarfen checkout field race (ADP-style early build)', () => {
+	test.beforeAll( () => {
+		writeMuPlugin( FIXTURE_SLUG, FIXTURE_PHP );
+		wp( [ 'option', 'update', FIXTURE_OPTION, 'yes' ] );
+	} );
+
+	test.afterAll( () => {
+		wp( [ 'option', 'delete', FIXTURE_OPTION ], { allowFailure: true } );
+		deleteMuPlugin( FIXTURE_SLUG );
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'İlçe stays a Hezarfen select dropdown despite an early get_checkout_fields() (guest)', async ( {
+		page,
+	} ) => {
+		await page.goto( '/checkout/' );
+		await waitForCheckoutIdle( page );
+
+		await expect( page.locator( '#billing_country' ) ).toHaveValue( 'TR' );
+
+		// The bug: the early get_checkout_fields() locks in WooCommerce's
+		// default text input for billing_city, so Hezarfen never turns it into
+		// the il-driven district <select>.
+		await expect( page.locator( 'select#billing_city' ) ).toBeAttached();
+		await expect( page.locator( 'input#billing_city' ) ).toHaveCount( 0 );
+
+		// And it must still work end-to-end: picking the il triggers the
+		// district AJAX and populates İlçe options.
+		const districtPromise = expectMahalleAjax( page, 'district' );
+		await pickFromSelect(
+			page,
+			'#billing_state',
+			TR_SAMPLE_ADDRESS.cityPlate
+		);
+		await districtPromise;
+
+		const districts = await page
+			.locator( '#billing_city option' )
+			.allTextContents();
+		expect( districts ).toContain( TR_SAMPLE_ADDRESS.district );
+	} );
+} );

--- a/tests/e2e/checkout-district-neighborhood-disabled.spec.ts
+++ b/tests/e2e/checkout-district-neighborhood-disabled.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test, type Page } from '@playwright/test';
+import { addE2EProductToCart, waitForCheckoutIdle } from './helpers/checkout';
+import { deleteMuPlugin, writeMuPlugin } from './helpers/mu-plugin';
+import { wp } from './helpers/wp-cli';
+
+/**
+ * Regression: the district/neighborhood feature must be fully switch-off-able.
+ *
+ * Checkout::is_district_neighborhood_enabled() gates every TR İlçe/Mahalle
+ * transformation:
+ *
+ *   return 'yes' === apply_filters(
+ *     'hezarfen_enable_district_neighborhood_fields',
+ *     get_option( 'hezarfen_enable_district_neighborhood_fields', 'yes' )
+ *   );
+ *
+ * When it returns false Hezarfen must leave WooCommerce's stock fields alone:
+ * #billing_city (İlçe) and #billing_address_1 (Mahalle) stay plain text
+ * <input>s and never become Hezarfen <select> dropdowns. If a refactor ever
+ * runs the field transformation unconditionally, a store that deliberately
+ * turned the feature off would suddenly get the il-driven selects back — this
+ * spec catches that.
+ *
+ * Both off-switches are covered because both feed the same gate:
+ *   1. the `hezarfen_enable_district_neighborhood_fields` option set to 'no'
+ *   2. a third-party `hezarfen_enable_district_neighborhood_fields` filter
+ *      forcing 'no' while the option stays at its default 'yes'
+ *
+ * The whole suite otherwise runs with the option forced to 'yes' (see
+ * global-setup.ts), so each block restores that default on teardown.
+ */
+const OPTION = 'hezarfen_enable_district_neighborhood_fields';
+
+async function expectPlainAddressInputs( page: Page ) {
+	await page.goto( '/checkout/' );
+	await waitForCheckoutIdle( page );
+
+	// Default country = TR (set by global-setup); only the disabled gate, not
+	// a non-TR country, should keep these as plain inputs here.
+	await expect( page.locator( '#billing_country' ) ).toHaveValue( 'TR' );
+
+	await expect( page.locator( 'input#billing_city' ) ).toBeAttached();
+	await expect( page.locator( 'input#billing_address_1' ) ).toBeAttached();
+	await expect( page.locator( 'select#billing_city' ) ).toHaveCount( 0 );
+	await expect( page.locator( 'select#billing_address_1' ) ).toHaveCount( 0 );
+}
+
+test.describe( 'Hezarfen İlçe/Mahalle option ile kapalıyken', () => {
+	test.beforeAll( () => {
+		wp( [ 'option', 'update', OPTION, 'no' ] );
+	} );
+
+	test.afterAll( () => {
+		// Restore the suite-wide default from global-setup.
+		wp( [ 'option', 'update', OPTION, 'yes' ] );
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'city/address_1 düz input kalır, select olmaz (option=no)', async ( {
+		page,
+	} ) => {
+		await expectPlainAddressInputs( page );
+	} );
+} );
+
+const FILTER_SLUG = 'hezarfen-e2e-disable-district-neighborhood-filter';
+const FILTER_PHP = `<?php
+/**
+ * E2E fixture: a third-party plugin/theme disabling Hezarfen's TR
+ * district/neighborhood fields purely via the public filter, leaving the
+ * option at its default 'yes'. Exercises the filter arm of
+ * Checkout::is_district_neighborhood_enabled().
+ */
+add_filter( 'hezarfen_enable_district_neighborhood_fields', function () {
+	return 'no';
+} );
+`;
+
+test.describe( 'Hezarfen İlçe/Mahalle filter ile kapatılınca', () => {
+	test.beforeAll( () => {
+		writeMuPlugin( FILTER_SLUG, FILTER_PHP );
+	} );
+
+	test.afterAll( () => {
+		deleteMuPlugin( FILTER_SLUG );
+	} );
+
+	test.beforeEach( async ( { page } ) => {
+		await addE2EProductToCart( page );
+	} );
+
+	test( 'city/address_1 düz input kalır, select olmaz (filter=no)', async ( {
+		page,
+	} ) => {
+		await expectPlainAddressInputs( page );
+	} );
+} );

--- a/tests/e2e/checkout-district-neighborhood-disabled.spec.ts
+++ b/tests/e2e/checkout-district-neighborhood-disabled.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
 import { addE2EProductToCart, waitForCheckoutIdle } from './helpers/checkout';
-import { deleteMuPlugin, writeMuPlugin } from './helpers/mu-plugin';
 import { wp } from './helpers/wp-cli';
 
 /**
@@ -14,20 +13,16 @@ import { wp } from './helpers/wp-cli';
  *     get_option( 'hezarfen_enable_district_neighborhood_fields', 'yes' )
  *   );
  *
- * When it returns false Hezarfen must leave WooCommerce's stock fields alone:
- * #billing_city (İlçe) and #billing_address_1 (Mahalle) stay plain text
- * <input>s and never become Hezarfen <select> dropdowns. If a refactor ever
- * runs the field transformation unconditionally, a store that deliberately
- * turned the feature off would suddenly get the il-driven selects back — this
- * spec catches that.
- *
- * Both off-switches are covered because both feed the same gate:
- *   1. the `hezarfen_enable_district_neighborhood_fields` option set to 'no'
- *   2. a third-party `hezarfen_enable_district_neighborhood_fields` filter
- *      forcing 'no' while the option stays at its default 'yes'
+ * When the `hezarfen_enable_district_neighborhood_fields` option is set to
+ * 'no', Hezarfen must leave WooCommerce's stock fields alone: #billing_city
+ * (İlçe) and #billing_address_1 (Mahalle) stay plain text <input>s and never
+ * become Hezarfen <select> dropdowns. If a refactor ever runs the field
+ * transformation unconditionally, a store that deliberately turned the
+ * feature off would suddenly get the il-driven selects back — this spec
+ * catches that.
  *
  * The whole suite otherwise runs with the option forced to 'yes' (see
- * global-setup.ts), so each block restores that default on teardown.
+ * global-setup.ts), so we restore that default on teardown.
  */
 const OPTION = 'hezarfen_enable_district_neighborhood_fields';
 
@@ -60,39 +55,6 @@ test.describe( 'Hezarfen İlçe/Mahalle option ile kapalıyken', () => {
 	} );
 
 	test( 'city/address_1 düz input kalır, select olmaz (option=no)', async ( {
-		page,
-	} ) => {
-		await expectPlainAddressInputs( page );
-	} );
-} );
-
-const FILTER_SLUG = 'hezarfen-e2e-disable-district-neighborhood-filter';
-const FILTER_PHP = `<?php
-/**
- * E2E fixture: a third-party plugin/theme disabling Hezarfen's TR
- * district/neighborhood fields purely via the public filter, leaving the
- * option at its default 'yes'. Exercises the filter arm of
- * Checkout::is_district_neighborhood_enabled().
- */
-add_filter( 'hezarfen_enable_district_neighborhood_fields', function () {
-	return 'no';
-} );
-`;
-
-test.describe( 'Hezarfen İlçe/Mahalle filter ile kapatılınca', () => {
-	test.beforeAll( () => {
-		writeMuPlugin( FILTER_SLUG, FILTER_PHP );
-	} );
-
-	test.afterAll( () => {
-		deleteMuPlugin( FILTER_SLUG );
-	} );
-
-	test.beforeEach( async ( { page } ) => {
-		await addE2EProductToCart( page );
-	} );
-
-	test( 'city/address_1 düz input kalır, select olmaz (filter=no)', async ( {
 		page,
 	} ) => {
 		await expectPlainAddressInputs( page );


### PR DESCRIPTION
Checkout sırasında ADP (Address Display Plugin) ile İlçe/Mahalle alanlarının boş gelmesi sorununu çözer (erken `get_checkout_fields` yarışı). TR ilçe/mahalle alan filtreleri `wp_loaded`'dan önce register edilir.

Bu değişiklik daha önce #172 ile yanlışlıkla doğrudan `master`'a merge edilmişti; o merge #173 ile geri alınıyor. Burada aynı değişiklikler `develop`'a karşı (yeni commit SHA'larıyla cherry-pick edilerek) doğru release akışıyla yeniden açılıyor.

İçerik:
- `includes/Checkout.php` — TR ilçe/mahalle alan filtrelerini `wp_loaded` öncesi register et
- `tests/e2e/checkout-adp-field-race.spec.ts` — yarışı tekrar eden e2e testi
