### PR TITLE
Hezarfen Pro reklam ve tanıtımları kaldırıldı

### DIFF
--- a/hezarfen-for-woocommerce.php
+++ b/hezarfen-for-woocommerce.php
@@ -35,7 +35,28 @@ define( 'WC_HEZARFEN_UYGULAMA_YOLU', plugin_dir_path( __FILE__ ) );
 define( 'WC_HEZARFEN_UYGULAMA_URL', plugin_dir_url( __FILE__ ) );
 define( 'WC_HEZARFEN_NEIGH_API_URL', plugin_dir_url( __FILE__ ) . 'api/get-mahalle-data.php' );
 
+/**
+ * Feature flag: show Hezarfen Pro promotions.
+ *
+ * Controls every in-app Pro promotion surface (the "Yükselt" submenu, the
+ * upgrade page, the settings page upgrade badge and the roadmap Pro feature
+ * survey). Disabled by default; flip to true here (or define it in wp-config.php)
+ * to bring the Pro promotions back in a future version.
+ */
+if ( ! defined( 'HEZARFEN_SHOW_PRO_PROMOTIONS' ) ) {
+	define( 'HEZARFEN_SHOW_PRO_PROMOTIONS', false );
+}
+
 add_action( 'plugins_loaded', 'hezarfen_init_plugin', 8 );
+
+/**
+ * Whether Hezarfen Pro promotions should be displayed.
+ *
+ * @return bool
+ */
+function hezarfen_show_pro_promotions() {
+	return defined( 'HEZARFEN_SHOW_PRO_PROMOTIONS' ) && HEZARFEN_SHOW_PRO_PROMOTIONS;
+}
 
 /**
  * Initialize plugin after checking requirements

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -131,8 +131,8 @@ class Admin_Menu {
             'admin.php?page=wc-settings&tab=hezarfen'
         );
 
-        // Only show upgrade menu if Hezarfen Pro is not installed
-        if ( ! $this->is_pro_installed() ) {
+        // Only show upgrade menu if Pro promotions are enabled and Hezarfen Pro is not installed
+        if ( hezarfen_show_pro_promotions() && ! $this->is_pro_installed() ) {
             add_submenu_page(
                 self::MENU_SLUG,
                 __( 'Yükselt', 'hezarfen-for-woocommerce' ),
@@ -154,8 +154,8 @@ class Admin_Menu {
      * @return void
      */
     public function enqueue_upgrade_styles( $hook ) {
-        // Don't add upgrade styles if Hezarfen Pro is installed
-        if ( $this->is_pro_installed() ) {
+        // Don't add upgrade styles if Pro promotions are disabled or Hezarfen Pro is installed
+        if ( ! hezarfen_show_pro_promotions() || $this->is_pro_installed() ) {
             return;
         }
 
@@ -579,6 +579,10 @@ class Admin_Menu {
      * @return void
      */
     public function render_upgrade_page() {
+        // Bail if Pro promotions are disabled or Hezarfen Pro is installed
+        if ( ! hezarfen_show_pro_promotions() || $this->is_pro_installed() ) {
+            return;
+        }
         ?>
         <div class="wrap hezarfen-upgrade-wrap">
             <h1><?php esc_html_e( 'Hezarfen Paketleri', 'hezarfen-for-woocommerce' ); ?></h1>
@@ -988,8 +992,8 @@ class Admin_Menu {
      * @return void
      */
     public function add_upgrade_button_to_settings() {
-        // Don't show if Pro is installed
-        if ( $this->is_pro_installed() ) {
+        // Don't show if Pro promotions are disabled or Pro is installed
+        if ( ! hezarfen_show_pro_promotions() || $this->is_pro_installed() ) {
             return;
         }
 

--- a/includes/admin/settings/class-hezarfen-settings-hezarfen.php
+++ b/includes/admin/settings/class-hezarfen-settings-hezarfen.php
@@ -1316,7 +1316,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 				</p>
 			</div>
 
-			<div class="hezarfen-roadmap-sections" style="display: grid; grid-template-columns: 1fr 1fr; gap: 30px; margin-bottom: 20px;">
+			<div class="hezarfen-roadmap-sections" style="display: grid; grid-template-columns: <?php echo hezarfen_show_pro_promotions() ? '1fr 1fr' : '1fr'; ?>; gap: 30px; margin-bottom: 20px;">
 				<!-- Free Features -->
 				<div class="hezarfen-roadmap-section">
 					<h3 style="margin-bottom: 15px; color: #0073aa;">
@@ -1334,6 +1334,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 				</div>
 
 				<!-- Pro Features -->
+				<?php if ( hezarfen_show_pro_promotions() ) : ?>
 				<div class="hezarfen-roadmap-section">
 					<h3 style="margin-bottom: 15px; color: #16a34a;">
 						<?php esc_html_e( 'Pro Paket (Ücretli Sürüm) Özellikleri', 'hezarfen-for-woocommerce' ); ?>
@@ -1374,6 +1375,7 @@ class Hezarfen_Settings_Hezarfen extends WC_Settings_Page {
 						</p>
 					</div>
 				</div>
+				<?php endif; ?>
 			</div>
 
 			<!-- Additional Details -->

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,7 @@ WooCommerce Kargo Takip eklentisi: ücretsiz Hepsijet entegrasyonu, 23 kargo fir
 = ⭐ TAMAMEN ÜCRETSİZ =
 
 **🚚 Hepsijet Ücretsiz WooCommerce Kargo Entegrasyonu**
-• 1-4 Desi 89,24TL+KDV - (Hezarfen Pro gerekmez!) Anlaşma yapmanıza gerek yok, kargokit.com'dan kayıt olun, bakiye yükleyin ve gönderime başlayın. Kargo gönderim için minimum limit yok! İster ayda 1 tane, ister 10000 tane!
+• 1-4 Desi 89,24TL+KDV - Anlaşma yapmanıza gerek yok, kargokit.com'dan kayıt olun, bakiye yükleyin ve gönderime başlayın. Kargo gönderim için minimum limit yok! İster ayda 1 tane, ister 10000 tane!
 • Ücretsiz entegrasyon (otomatik kargo takip no girişi, otomatik siparişin kargoya verildi durumuna geçmesi, otomatik siparişin tamamlandı durumuna geçmesi, otomatik müşteriye e-posta bildirimi)
 
 **🚚 Kargo Yönetimi ve WooCommerce Kargo Takip Modülü**
@@ -145,7 +145,7 @@ Hezarfen çalışmak için minimum WooCommerce 6.9.0 sürümüne ihtiyaç duyar,
 Eğitim videoları ve rehberler için [Hezarfen YouTube resmi kanalımızı](https://www.youtube.com/@hezarfenforwoocommerce) ziyaret edebilir ve abone olabilirsiniz.
 
 = Bu WooCommerce eklentisi tamamen ücretsiz mi? =
-Evet, yukarıda listelenen özellikler tamamen ücretsizdir. Intense Anlaşmalı Hepsijet Kargo Entegrasyonu (otomatik takip no girişi, otomatik sipariş durumunun kargoya verildi veya tamamlandı olması, bildirimler), 23 kargo firması için manuel takip, WooCommerce kargo takip modülü, il/ilçe/mahalle seçimi, TC kimlik no alanı gibi özellikler ücretsiz sunulmaktadır. Ayrıca, Hezarfen'in intense.com.tr üzerinde satılan Pro versiyonu mevcuttur. Pro versiyonda otomatik woocommerce kargo entegrasyonu (kendi kargo anlaşmalarınızla), Paraşüt e-arşiv/e-fatura entegrasyonu özellikleri bulunmaktadır.
+Evet, yukarıda listelenen özellikler tamamen ücretsizdir. Intense Anlaşmalı Hepsijet Kargo Entegrasyonu (otomatik takip no girişi, otomatik sipariş durumunun kargoya verildi veya tamamlandı olması, bildirimler), 23 kargo firması için manuel takip, WooCommerce kargo takip modülü, il/ilçe/mahalle seçimi, TC kimlik no alanı gibi özellikler ücretsiz sunulmaktadır.
 
 = Hangi WooCommerce sürümleriyle uyumlu? =
 WooCommerce 5.0 ve üzeri tüm sürümlerle uyumludur. HPOS (High Performance Order Storage) desteği mevcuttur.
@@ -165,11 +165,8 @@ Tüm il/ilçe/mahalle verileri eklenti içerisinde yer almaktadır. İnternet ba
 = Kurumsal ve bireysel fatura ayrımı nasıl yapılır? =
 WooCommerce > Ayarlar > Hezarfen > Ödeme Sayfası Ayarları menüsünden "Ödeme ekranında vergi alanlarını göster" seçeneğini aktifleştirdiğinizde, müşterileriniz kurumsal veya bireysel fatura seçimi yapabilir.
 
-= Pro sürüme geçiş yapmak veri kaybına neden olur mu? =
-Hayır, Pro sürüme geçiş yaptığınızda mevcut tüm verileriniz korunur. Sadece yeni özellikler eklenir.
-
 = Destek nasıl alabilirim? =
-Ücretsiz versiyonumuz için WordPress.org destek forumunu kullanabilir, Pro versiyonumuz için [intense.com.tr](https://intense.com.tr) üzerinden bizimle iletişime geçebilirsiniz.
+Ücretsiz versiyonumuz için WordPress.org destek forumunu kullanabilir, ayrıca [intense.com.tr](https://intense.com.tr) üzerinden bizimle iletişime geçebilirsiniz.
 
 = Kaybolan şifreleme anahtarını nasıl kurtarabilirim? =
 WooCommerce > Ayarlar > Hezarfen > Şifreleme Anahtarı Kurtarma bölümünden yeni anahtar oluşturabilirsiniz. Oluşturulan anahtarı wp-config.php dosyanıza eklemeniz gerekir. Detaylı bilgi için dokümantasyonu inceleyin.


### PR DESCRIPTION
## Özet

Hezarfen Pro ile ilgili uygulama içi reklamlar ve readme tanıtımları kaldırıldı. Reklamlar tamamen silinmek yerine bir **feature flag** (`HEZARFEN_SHOW_PRO_PROMOTIONS`) arkasına alındı; varsayılan `false` (gizli), ileride gerekirse `true` yapılarak geri açılabilir.

## Değişiklikler

### Feature flag (`hezarfen-for-woocommerce.php`)
- `HEZARFEN_SHOW_PRO_PROMOTIONS` sabiti tanımlandı (varsayılan `false`, `wp-config.php`'den de override edilebilir).
- `hezarfen_show_pro_promotions()` yardımcı fonksiyonu eklendi.

### Uygulama içi Pro reklamları flag'e bağlandı (`includes/admin/class-admin-menu.php`)
- "Yükselt" alt menüsü
- Upgrade (Hezarfen Paketleri) sayfası — doğrudan URL ile erişimde de render edilmiyor
- Upgrade sayfası stilleri
- Ayarlar sayfasındaki "Yükselt" badge'i

### Roadmap anketi (`includes/admin/settings/class-hezarfen-settings-hezarfen.php`)
- "Pro Paket (Ücretli Sürüm) Özellikleri" bölümü ve "Mevcut Pro Paket Özellikleri" fiyat tanıtımı flag'e bağlandı.
- Flag kapalıyken grid tek sütuna düşüyor (yalnızca ücretsiz özellikler anketi gösteriliyor).

### readme.txt
- Description ve SSS bölümlerinden Hezarfen Pro tanıtımları kaldırıldı (`Pro versiyonu mevcuttur...`, `Pro sürüme geçiş...` SSS, destek metnindeki Pro referansı, `(Hezarfen Pro gerekmez!)` ifadesi).
- Changelog korundu.

## Notlar
- Pro kurulu olduğunda zaten gizlenen mevcut davranış (`is_pro_installed()`) korunuyor.
- PHP lint tüm değiştirilen dosyalarda temiz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)