### PR TITLE
Yurtiçi Kargo talep anketi kaldırıldı

### DIFF
--- a/packages/manual-shipment-tracking/includes/admin/class-admin-ajax.php
+++ b/packages/manual-shipment-tracking/includes/admin/class-admin-ajax.php
@@ -115,8 +115,7 @@ class Admin_Ajax {
 		}
 
 		$carriers = array(
-			'aras'    => __( 'Aras Kargo', 'hezarfen-for-woocommerce' ),
-			'yurtici' => __( 'Yurtiçi Kargo', 'hezarfen-for-woocommerce' ),
+			'aras' => __( 'Aras Kargo', 'hezarfen-for-woocommerce' ),
 		);
 
 		$usage_options = array(

--- a/packages/manual-shipment-tracking/templates/order-edit/metabox-shipment.php
+++ b/packages/manual-shipment-tracking/templates/order-edit/metabox-shipment.php
@@ -84,17 +84,6 @@ $kargokit_survey_carriers = apply_filters(
                 __( '3 Desi/Kg', 'hezarfen-for-woocommerce' ) => __( '123,87 TL + KDV', 'hezarfen-for-woocommerce' ),
             ),
         ),
-        // Yurtiçi kartı yalnızca geniş ekranlarda gösterilir (Aras kartındaki tanıtım metninin yerine).
-        'yurtici' => array(
-            'title'            => __( 'Yurtiçi Kargo', 'hezarfen-for-woocommerce' ),
-            'logo'             => Helper::get_courier_class( 'yurtici' )::$logo,
-            'price_line'       => __( '1 Desi · Tüm Türkiye · 125 TL + KDV', 'hezarfen-for-woocommerce' ),
-            'modal_price_line' => __( 'Tüm Türkiye · 125 TL + KDV = 150 TL her şey dahil', 'hezarfen-for-woocommerce' ),
-            'card_class'       => 'hidden 3xl:flex',
-            'pricing_tiers'    => array(
-                __( '1 Desi/Kg', 'hezarfen-for-woocommerce' ) => __( '125,00 TL + KDV', 'hezarfen-for-woocommerce' ),
-            ),
-        ),
     )
 );
 


### PR DESCRIPTION
Sipariş düzenleme ekranındaki Kargokit talep anketinden Yurtiçi Kargo çıkarıldı. Ankette yalnızca Aras Kargo kalıyor.

## Değişiklikler

- `metabox-shipment.php` — `$kargokit_survey_carriers` dizisinden `yurtici` kaydı silindi. Hem banner kartı hem modal aynı diziyi `foreach` ile dolaştığı için tek kayıt silmek her ikisini de kaldırıyor.
- `class-admin-ajax.php` — `kargokit_survey()` içindeki izinli kargo listesinden `yurtici` çıkarıldı; elle hazırlanmış bir POST ile Yurtiçi yanıtı gönderilemiyor.

## Dokunulmayan yerler

- Yurtiçi'nin normal kargo entegrasyonu (`Courier_Yurtici`, takip URL'i, kargo firması seçici) aynen duruyor.
- Aras banner'ının yanındaki boş hücreyi dolduran, öne alınmış normal Yurtiçi kartı korundu. Breakpoint'lere göre kontrol edildi: Aras tek başınayken de `xl` (3 kolonun 2'si) ve `2xl` (4 kolonun 3'ü) seviyelerinde boşluk kalıyor, yani öne alma hâlâ işlevini görüyor.

## Notlar

- Sürüm bump'ı bilinçli olarak yapılmadı — repo'da release bump'ları ayrı `chore(release)` PR'ı olarak gidiyor (#183, #185).
- Daha önce Yurtiçi yanıtı göndermiş sitelerde `hezarfen_kargokit_survey_yurtici` option'ı artık kullanılmıyor. Zararsız ölü veri; istenirse uninstall rutinine temizlik eklenebilir.

## Test

Her iki dosya `php -l` ile kontrol edildi, hata yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)