### PR TITLE
feat: Hezarfen Pro lisans/destek bitiş uyarısı

### DIFF
--- a/includes/Autoload.php
+++ b/includes/Autoload.php
@@ -121,6 +121,8 @@ class Autoload {
 	 */
 	public function load_plugin_files() {
 		require_once 'class-hezarfen-wc-helper.php';
+		require_once 'class-hezarfen-pro-license-monitor.php';
+		require_once 'class-hezarfen-pro-license-notice.php';
 		require_once 'class-hezarfen.php';
 		require_once 'Data/Abstracts/Abstract_Encryption.php';
 		require_once 'Data/PostMetaEncryption.php';

--- a/includes/class-hezarfen-pro-license-monitor.php
+++ b/includes/class-hezarfen-pro-license-monitor.php
@@ -1,0 +1,450 @@
+<?php
+/**
+ * Monitors Hezarfen Pro license/subscription expiry from intense.com.tr.
+ *
+ * Reads Pro's WooCommerce API Manager client options (read-only) and polls the
+ * remote status endpoint on a daily cron to cache when support/updates expire.
+ * Exposes a single public getter used by the UI layer to render notices.
+ *
+ * @package Hezarfen\Inc
+ */
+
+namespace Hezarfen\Inc;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Pro_License_Monitor — data layer for license expiry tracking.
+ */
+class Pro_License_Monitor {
+
+	const CRON_HOOK           = 'hezarfen_check_pro_license_expiry';
+	const OPT_LAST_RESPONSE   = 'hezarfen_pro_license_last_response';
+	const OPT_STATUS_CACHE    = 'hezarfen_pro_license_status_cache';
+	const OPT_LAST_ERROR      = 'hezarfen_pro_license_last_error';
+	const OPT_LAST_SUCCESS_TS = 'hezarfen_pro_license_last_success';
+
+	const PRO_PRODUCT_ID    = 18509;
+	const PRO_DATA_KEY      = 'wc_am_client_18509';
+	const PRO_INSTANCE_KEY  = 'wc_am_client_18509_instance';
+	const PRO_ACTIVATED_KEY = 'wc_am_client_18509_activated';
+
+	const API_BASE          = 'https://intense.com.tr/';
+	const WARNING_THRESHOLD = 30 * DAY_IN_SECONDS;
+	const STALE_THRESHOLD   = 7 * DAY_IN_SECONDS;
+
+	/**
+	 * API base URL'ini döndürür. Local end-to-end test için
+	 * `define('HEZARFEN_PRO_LICENSE_API_BASE', 'http://intense.local/')`
+	 * tanımlanırsa override kullanılır; production'da default kalır.
+	 *
+	 * @return string
+	 */
+	public static function get_api_base() {
+		if ( defined( 'HEZARFEN_PRO_LICENSE_API_BASE' ) && HEZARFEN_PRO_LICENSE_API_BASE ) {
+			return trailingslashit( (string) HEZARFEN_PRO_LICENSE_API_BASE );
+		}
+		return self::API_BASE;
+	}
+
+	/**
+	 * Override aktif mi? (intense.local gibi private host'lara wp_safe_remote_post
+	 * loopback bloku uyguladığı için override'da wp_remote_post'a düşürülür.)
+	 *
+	 * @return bool
+	 */
+	public static function is_api_base_overridden() {
+		return defined( 'HEZARFEN_PRO_LICENSE_API_BASE' ) && HEZARFEN_PRO_LICENSE_API_BASE && self::API_BASE !== HEZARFEN_PRO_LICENSE_API_BASE;
+	}
+
+	/**
+	 * Constructor — register hooks.
+	 */
+	public function __construct() {
+		add_action( self::CRON_HOOK, array( $this, 'run_check' ) );
+		add_action( 'admin_init', array( $this, 'schedule_cron' ) );
+		add_action( 'admin_init', array( $this, 'maybe_initial_sync' ) );
+		add_action( 'current_screen', array( $this, 'maybe_refresh_on_license_screen' ) );
+
+		register_deactivation_hook( WC_HEZARFEN_FILE, array( __CLASS__, 'unschedule_cron' ) );
+	}
+
+	/**
+	 * Pro lisans sayfası açıldığında son sync 1 saatten eskiyse anında taze veri çek.
+	 * Müşteri intense.com.tr'de yenileme yaptıktan sonra kendi sitesine dönüp
+	 * lisans sayfasını açtığında banner'ın hemen güncel görünmesini sağlar.
+	 *
+	 * @return void
+	 */
+	public function maybe_refresh_on_license_screen() {
+		if ( ! is_admin() ) {
+			return;
+		}
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+		if ( false === strpos( (string) $screen->id, 'wc_am_client_' . self::PRO_PRODUCT_ID . '_dashboard' ) ) {
+			return;
+		}
+		$last = (int) get_option( self::OPT_LAST_SUCCESS_TS );
+		if ( $last > 0 && ( time() - $last ) < HOUR_IN_SECONDS ) {
+			return; // son 1 saat içinde zaten çekilmiş
+		}
+		$this->run_check();
+	}
+
+	/**
+	 * Detects whether Hezarfen Pro is installed and licensed.
+	 *
+	 * @return bool
+	 */
+	public static function is_pro_detected() {
+		if ( defined( 'HEZARFEN_PRO_VERSION' ) ) {
+			return true;
+		}
+		if ( get_option( 'hezarfen_pro_db_version' ) ) {
+			return true;
+		}
+		$data = get_option( self::PRO_DATA_KEY );
+		return is_array( $data ) && ! empty( $data );
+	}
+
+	/**
+	 * Schedules the daily cron event if not already scheduled.
+	 *
+	 * @return void
+	 */
+	public function schedule_cron() {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Clears the cron on plugin deactivation.
+	 *
+	 * @return void
+	 */
+	public static function unschedule_cron() {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Triggers an initial sync the first time Pro is detected.
+	 *
+	 * @return void
+	 */
+	public function maybe_initial_sync() {
+		if ( get_option( self::OPT_LAST_SUCCESS_TS ) ) {
+			return;
+		}
+		if ( ! self::is_pro_detected() ) {
+			return;
+		}
+		if ( wp_next_scheduled( self::CRON_HOOK . '_initial' ) ) {
+			return;
+		}
+		wp_schedule_single_event( time() + 30, self::CRON_HOOK . '_initial' );
+		add_action( self::CRON_HOOK . '_initial', array( $this, 'run_check' ) );
+	}
+
+	/**
+	 * Taze veri çeker. "Tazele" butonu için kullanılır.
+	 *
+	 * run_check() başarılı ise cache'i yeni değerle üstüne yazar, başarısız ise
+	 * eski cache korunur — bu yüzden cache'i önceden silmiyoruz (API fail olursa
+	 * kart boşa gitmesin). Ayrıca intense.com.tr tarafına hezarfen_force_flush=1
+	 * sinyali gönderir ki WCAM cache'i de invalidate edilsin.
+	 *
+	 * @return void
+	 */
+	public function force_refresh() {
+		$this->run_check( true );
+	}
+
+	/**
+	 * Cron callback — fetches remote status and updates the cache.
+	 *
+	 * @param bool $force_flush intense.com.tr tarafına WCAM cache'ini zorla flush
+	 *                          etmesi için sinyal gönder. Sadece manuel "Tazele"
+	 *                          buton akışından true olarak çağırılır.
+	 * @return void
+	 */
+	public function run_check( $force_flush = false ) {
+		if ( ! self::is_pro_detected() ) {
+			return;
+		}
+		if ( 'Activated' !== get_option( self::PRO_ACTIVATED_KEY ) ) {
+			return;
+		}
+
+		$response = $this->fetch_status( $force_flush );
+		if ( ! is_array( $response ) ) {
+			return;
+		}
+
+		$resource         = $this->parse_resource( $response );
+		$remote_activated = ! empty( $response['data']['activated'] );
+		$this->update_cache( $resource, $remote_activated );
+	}
+
+	/**
+	 * Performs the POST request to the WCAM status endpoint.
+	 *
+	 * @param bool $force_flush intense.com.tr tarafına WCAM cache flush sinyali gönder.
+	 * @return array|null Decoded response array or null on failure.
+	 */
+	public function fetch_status( $force_flush = false ) {
+		$data     = get_option( self::PRO_DATA_KEY );
+		$api_key  = is_array( $data ) && isset( $data[ self::PRO_DATA_KEY . '_api_key' ] )
+			? (string) $data[ self::PRO_DATA_KEY . '_api_key' ]
+			: '';
+		$instance = (string) get_option( self::PRO_INSTANCE_KEY );
+		$domain   = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+
+		if ( '' === $api_key || '' === $instance || '' === $domain ) {
+			return null;
+		}
+
+		$args = array(
+			'wc-api'       => 'wc-am-api',
+			'wc_am_action' => 'status',
+			'api_key'      => $api_key,
+			'product_id'   => self::PRO_PRODUCT_ID,
+			'instance'     => $instance,
+			'object'       => $domain,
+		);
+		if ( $force_flush ) {
+			$args['hezarfen_force_flush'] = 1;
+		}
+		$url = add_query_arg( $args, self::get_api_base() );
+
+		// Override aktifse wp_safe_remote_post loopback'i blokladığı için wp_remote_post kullan.
+		$response = self::is_api_base_overridden()
+			? wp_remote_post( esc_url_raw( $url ), array( 'timeout' => 15 ) )
+			: wp_safe_remote_post( esc_url_raw( $url ), array( 'timeout' => 15 ) );
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			update_option(
+				self::OPT_LAST_ERROR,
+				array(
+					'at'  => time(),
+					'msg' => is_wp_error( $response )
+						? $response->get_error_message()
+						: 'HTTP ' . wp_remote_retrieve_response_code( $response ),
+				),
+				false
+			);
+			return null;
+		}
+
+		$body = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) ) {
+			return null;
+		}
+
+		if ( ! defined( 'HEZARFEN_DEBUG_LICENSE_RESPONSE' ) || HEZARFEN_DEBUG_LICENSE_RESPONSE ) {
+			update_option( self::OPT_LAST_RESPONSE, $body, false );
+		}
+		update_option( self::OPT_LAST_SUCCESS_TS, time(), false );
+		delete_option( self::OPT_LAST_ERROR );
+
+		return $body;
+	}
+
+	/**
+	 * Extracts the Hezarfen Pro resource (product 18509) from the WCAM status response.
+	 *
+	 * @param array<string, mixed> $response Decoded status response.
+	 * @return array<string, mixed>|null
+	 */
+	public function parse_resource( array $response ) {
+		$resources = $response['data']['api_key_expirations']['wc_subs_resources'] ?? null;
+		if ( ! is_array( $resources ) ) {
+			return null;
+		}
+
+		// En uzak support_expires_ts'e sahip resource'u seç — müşteri aynı key'e
+		// bağlı birden fazla yenileme yapmışsa en son yenilemenin tarihi görünsün.
+		$latest = null;
+		foreach ( $resources as $resource ) {
+			if ( ! is_array( $resource ) ) {
+				continue;
+			}
+			if ( (int) ( $resource['product_id'] ?? 0 ) !== self::PRO_PRODUCT_ID ) {
+				continue;
+			}
+			$ts = isset( $resource['support_expires_ts'] ) ? (int) $resource['support_expires_ts'] : 0;
+			if ( $ts <= 0 ) {
+				continue;
+			}
+			if ( null === $latest || $ts > (int) $latest['support_expires_ts'] ) {
+				$latest = $resource;
+			}
+		}
+
+		return $latest;
+	}
+
+	/**
+	 * Backwards-compatible wrapper: returns only the timestamp.
+	 *
+	 * @param array<string, mixed> $response Decoded status response.
+	 * @return int|null
+	 */
+	public function parse_support_expires_ts( array $response ) {
+		$resource = $this->parse_resource( $response );
+		return is_array( $resource ) ? (int) $resource['support_expires_ts'] : null;
+	}
+
+	/**
+	 * Returns the full Pro API key from the WCAM client option (empty string if absent).
+	 *
+	 * @return string
+	 */
+	public function get_api_key() {
+		$data = get_option( self::PRO_DATA_KEY );
+		if ( is_array( $data ) && ! empty( $data[ self::PRO_DATA_KEY . '_api_key' ] ) ) {
+			return (string) $data[ self::PRO_DATA_KEY . '_api_key' ];
+		}
+		return '';
+	}
+
+	/**
+	 * Updates the normalized status cache from a parsed resource.
+	 *
+	 * Müşteri intense.com.tr'de lisansını pasif etse bile WCAM cevabı
+	 * api_key_expirations alanını dolu döndürebiliyor; bu durumda local
+	 * cache eski expiry'lere göre "ok" durumuna düşmesin diye, gerçek
+	 * uzak aktivasyon bayrağını (`remote_activated`) ayrıca saklıyoruz.
+	 *
+	 * @param array<string, mixed>|null $resource         Parsed resource.
+	 * @param bool                      $remote_activated En son API cevabındaki data.activated değeri.
+	 * @return void
+	 */
+	private function update_cache( $resource, $remote_activated = false ) {
+		$existing = get_option( self::OPT_STATUS_CACHE );
+		$cache    = is_array( $existing ) ? $existing : array();
+
+		if ( is_array( $resource ) ) {
+			$cache['support_expires_ts'] = (int) $resource['support_expires_ts'];
+			$cache['email_masked']       = isset( $resource['email_masked'] ) ? (string) $resource['email_masked'] : '';
+			$cache['sub_id']             = isset( $resource['sub_id'] ) ? (int) $resource['sub_id'] : 0;
+			$cache['order_id']           = isset( $resource['order_id'] ) ? (int) $resource['order_id'] : 0;
+		}
+
+		$cache['remote_activated'] = (bool) $remote_activated;
+		$cache['checked_at']       = time();
+
+		update_option( self::OPT_STATUS_CACHE, $cache, false );
+	}
+
+	/**
+	 * Returns the computed license state for the UI layer.
+	 *
+	 * @return array{status:string, support_expires_ts:int, days_left:int, checked_at:int}
+	 */
+	public function get_license_state() {
+		if ( ! self::is_pro_detected() ) {
+			return $this->empty_state( 'no_pro' );
+		}
+		if ( 'Activated' !== get_option( self::PRO_ACTIVATED_KEY ) ) {
+			return $this->empty_state( 'not_activated' );
+		}
+
+		$override        = apply_filters( 'hezarfen_pro_license_support_expires_override', null );
+		$email_override  = (string) apply_filters( 'hezarfen_pro_license_email_masked_override', '' );
+		$sub_id_override = (int) apply_filters( 'hezarfen_pro_license_sub_id_override', 0 );
+		if ( is_int( $override ) && $override > 0 ) {
+			return $this->compute_state_from_ts( $override, time(), $email_override, $sub_id_override );
+		}
+
+		$cache = get_option( self::OPT_STATUS_CACHE );
+
+		// Uzak taraf "deactivated" diyorsa local option ne derse desin
+		// lisans aktif değil — kart/expiry datası gösterilmemeli; ama sub/order
+		// metadata'sı renewal URL'ine sub_id geçirebilmek için state'te kalsın.
+		if ( is_array( $cache ) && array_key_exists( 'remote_activated', $cache ) && false === (bool) $cache['remote_activated'] ) {
+			return array(
+				'status'             => 'not_activated',
+				'support_expires_ts' => (int) ( $cache['support_expires_ts'] ?? 0 ),
+				'days_left'          => 0,
+				'checked_at'         => (int) ( $cache['checked_at'] ?? 0 ),
+				'email_masked'       => (string) ( $cache['email_masked'] ?? '' ),
+				'sub_id'             => (int) ( $cache['sub_id'] ?? 0 ),
+				'order_id'           => (int) ( $cache['order_id'] ?? 0 ),
+			);
+		}
+
+		if ( ! is_array( $cache ) || empty( $cache['support_expires_ts'] ) ) {
+			return $this->empty_state( 'unknown' );
+		}
+
+		$last_success = (int) get_option( self::OPT_LAST_SUCCESS_TS );
+		if ( $last_success > 0 && ( time() - $last_success ) > self::STALE_THRESHOLD ) {
+			return $this->empty_state( 'unknown' );
+		}
+
+		return $this->compute_state_from_ts(
+			(int) $cache['support_expires_ts'],
+			(int) ( $cache['checked_at'] ?? time() ),
+			(string) ( $cache['email_masked'] ?? '' ),
+			(int) ( $cache['sub_id'] ?? 0 ),
+			(int) ( $cache['order_id'] ?? 0 )
+		);
+	}
+
+	/**
+	 * Builds a license state array for status values that carry no timestamp.
+	 *
+	 * @param string $status Status label.
+	 * @return array{status:string, support_expires_ts:int, days_left:int, checked_at:int, email_masked:string}
+	 */
+	private function empty_state( $status ) {
+		return array(
+			'status'             => $status,
+			'support_expires_ts' => 0,
+			'days_left'          => 0,
+			'checked_at'         => 0,
+			'email_masked'       => '',
+			'sub_id'             => 0,
+			'order_id'           => 0,
+		);
+	}
+
+	/**
+	 * Computes status and days_left from a timestamp.
+	 *
+	 * @param int    $ts           Support expiry unix timestamp.
+	 * @param int    $checked_at   When the cache was last updated.
+	 * @param string $email_masked Optional masked email from the status response.
+	 * @param int    $sub_id       Optional subscription ID from the status response.
+	 * @return array{status:string, support_expires_ts:int, days_left:int, checked_at:int, email_masked:string, sub_id:int}
+	 */
+	private function compute_state_from_ts( $ts, $checked_at, $email_masked = '', $sub_id = 0, $order_id = 0 ) {
+		$now  = time();
+		$diff = $ts - $now;
+
+		if ( $diff <= 0 ) {
+			$status = 'expired';
+		} elseif ( $diff <= self::WARNING_THRESHOLD ) {
+			$status = 'expiring_soon';
+		} else {
+			$status = 'ok';
+		}
+
+		return array(
+			'status'             => $status,
+			'support_expires_ts' => $ts,
+			'days_left'          => (int) ceil( $diff / DAY_IN_SECONDS ),
+			'checked_at'         => $checked_at,
+			'email_masked'       => (string) $email_masked,
+			'sub_id'             => (int) $sub_id,
+			'order_id'           => (int) $order_id,
+		);
+	}
+}

--- a/includes/class-hezarfen-pro-license-notice.php
+++ b/includes/class-hezarfen-pro-license-notice.php
@@ -1,0 +1,717 @@
+<?php
+/**
+ * Renders expiry warnings for Hezarfen Pro across three surfaces:
+ *   1) global admin_notices (top of every admin screen)
+ *   2) plugins list row under Hezarfen Pro
+ *   3) in-page banner on the Pro license settings screen
+ *
+ * Dismissal is per-user and keyed to the current support_expires_ts so that
+ * a refreshed timestamp (e.g. after subscription renewal) automatically
+ * re-surfaces the notice.
+ *
+ * @package Hezarfen\Inc
+ */
+
+namespace Hezarfen\Inc;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * Pro_License_Notice — UI layer for license expiry warnings.
+ */
+class Pro_License_Notice {
+
+	const USER_META_DISMISSED    = 'hezarfen_pro_license_dismissed_for';
+	const AJAX_ACTION_DISMISS    = 'hezarfen_dismiss_pro_license_notice';
+	const NONCE_ACTION           = 'hezarfen_dismiss_pro_license_notice';
+	const REFRESH_ACTION         = 'hezarfen_refresh_pro_license';
+	const REFRESH_NONCE          = 'hezarfen_refresh_pro_license';
+	const PRO_LICENSE_SCREEN_KEY = 'wc_am_client_18509_dashboard';
+	const PURCHASE_URL           = 'https://intense.com.tr/odeme/?add-to-cart-multiple=18509,241';
+
+	/**
+	 * Monitor providing license state.
+	 *
+	 * @var Pro_License_Monitor
+	 */
+	private $monitor;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Pro_License_Monitor $monitor License monitor instance.
+	 */
+	public function __construct( Pro_License_Monitor $monitor ) {
+		$this->monitor = $monitor;
+
+		add_action( 'admin_notices', array( $this, 'render_admin_notice' ) );
+		add_action( 'admin_notices', array( $this, 'render_refresh_notice' ) );
+		add_action( 'all_admin_notices', array( $this, 'maybe_render_pro_page_banner' ) );
+		add_action( 'admin_footer', array( $this, 'inject_license_card_into_tab' ) );
+		add_action( 'wp_ajax_' . self::AJAX_ACTION_DISMISS, array( $this, 'handle_dismiss' ) );
+		add_action( 'admin_init', array( $this, 'handle_refresh_request' ) );
+
+		$pro_file = $this->get_pro_plugin_file();
+		if ( $pro_file ) {
+			add_action( 'after_plugin_row_' . $pro_file, array( $this, 'render_plugin_row_notice' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Resolves the Pro plugin file path (directory/filename.php form).
+	 *
+	 * @return string
+	 */
+	private function get_pro_plugin_file() {
+		if ( defined( 'HEZARFEN_PRO_FILE' ) ) {
+			return plugin_basename( HEZARFEN_PRO_FILE );
+		}
+		return 'hezarfen-pro-for-woocommerce/hezarfen-pro-for-woocommerce.php';
+	}
+
+	/**
+	 * Is the current admin screen the Pro license settings page?
+	 *
+	 * @return bool
+	 */
+	private function is_pro_license_screen() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return false;
+		}
+		return false !== strpos( (string) $screen->id, self::PRO_LICENSE_SCREEN_KEY );
+	}
+
+	/**
+	 * Has the current user dismissed the notice for this support_expires_ts?
+	 *
+	 * @param int $support_expires_ts Current timestamp from cache.
+	 * @return bool
+	 */
+	private function is_dismissed_for_current_expiry( $support_expires_ts ) {
+		$dismissed_for = (int) get_user_meta( get_current_user_id(), self::USER_META_DISMISSED, true );
+		return $dismissed_for === (int) $support_expires_ts;
+	}
+
+	/**
+	 * Renders the global admin_notices banner (suppressed on the Pro license screen).
+	 *
+	 * @return void
+	 */
+	public function render_admin_notice() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+		if ( $this->is_pro_license_screen() ) {
+			return; // In-page banner already renders there.
+		}
+
+		$state = $this->monitor->get_license_state();
+		if ( ! in_array( $state['status'], array( 'expiring_soon', 'expired' ), true ) ) {
+			return;
+		}
+
+		if ( 'expiring_soon' === $state['status']
+			&& $this->is_dismissed_for_current_expiry( (int) $state['support_expires_ts'] )
+		) {
+			return;
+		}
+
+		$this->print_standard_notice( $state );
+	}
+
+	/**
+	 * Renders the in-page banner on the Pro license settings screen.
+	 *
+	 * - expiring_soon / expired → turuncu veya kırmızı vurgulu "Lisansı Yenile" banner
+	 * - ok → yeşil vurgulu küçük "Lisansınız aktif" bilgi kartı
+	 * - diğer state'ler → hiçbir şey render etmez
+	 *
+	 * @return void
+	 */
+	public function maybe_render_pro_page_banner() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+		if ( ! $this->is_pro_license_screen() ) {
+			return;
+		}
+
+		$state = $this->monitor->get_license_state();
+
+		// Beyaz bilgi kartı artık admin_footer üzerinden JS ile form üstüne taşınıyor.
+		// Bu hook yalnızca uyarı banner'ı için (sayfa üstünde kalması uygun).
+		if ( ! in_array( $state['status'], array( 'expiring_soon', 'expired', 'not_activated' ), true ) ) {
+			return;
+		}
+
+		if ( 'not_activated' === $state['status'] ) {
+			$this->render_not_activated_banner( $state );
+			return;
+		}
+
+		$is_expired   = 'expired' === $state['status'];
+		$class        = $is_expired ? 'notice-error' : 'notice-warning';
+		$accent       = $is_expired ? '#d63638' : '#d54e21';
+		$bg           = $is_expired ? '#fff0f0' : '#fff4e5';
+		$style        = sprintf(
+			'padding:20px 24px;border-left-width:6px;border-left-color:%s;background:%s;margin:20px 0;',
+			$accent,
+			$bg
+		);
+		$purchase_url = $this->build_purchase_url( $state );
+		?>
+		<div class="notice <?php echo esc_attr( $class ); ?> hezarfen-pro-license-banner" style="<?php echo esc_attr( $style ); ?>">
+			<p style="font-size:14px;margin-top:0;">
+				<?php
+				echo wp_kses(
+					$is_expired
+						? __( 'Güvenlik yamaları, WooCommerce/WordPress uyumluluk güncellemeleri ve yeni kargo entegrasyonları artık bu siteye gelmiyor. Kesintisiz kullanım için lisansınızı yenileyin.', 'hezarfen-for-woocommerce' )
+						: __( 'Süre bittiğinde güvenlik yamaları, WooCommerce uyumluluk güncellemeleri ve yeni kargo entegrasyonları bu siteye gelmez. Kesintisiz kullanım için lisansınızı yenileyin.', 'hezarfen-for-woocommerce' ),
+					$this->allowed_html()
+				);
+				?>
+			</p>
+
+			<p style="margin-top:14px;">
+				<a href="<?php echo esc_url( $purchase_url ); ?>" target="_blank" rel="noopener" class="button button-primary button-hero">
+					<?php esc_html_e( 'Lisansı Yenile →', 'hezarfen-for-woocommerce' ); ?>
+				</a>
+			</p>
+
+			<p class="description" style="margin-top:8px;">
+				<?php
+				esc_html_e(
+					'Siteniz ve mevcut lisans bilgileriniz ödeme sayfasına otomatik iletilecek. Sipariş tamamlandıktan sonra size verilen yeni API anahtarını bu sayfadaki API anahtarı alanına yapıştırmanız yeterlidir. İşlemi mevcut intense.com.tr hesabınızdan veya yeni bir hesaptan yapabilirsiniz.',
+					'hezarfen-for-woocommerce'
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Lisans aktif değilken (yerel olarak hiç aktive edilmemiş ya da
+	 * intense.com.tr'de pasif edilmiş) lisans ayarları sayfasında üstte
+	 * gösterilen banner. Müşteri iki senaryodan hangisinde olduğunu kendisi
+	 * bildiği için tek banner her iki yola da yönlendiriyor: geçerli anahtarı
+	 * varsa aşağıdan aktif edebilir, aboneliği bitmişse yenileme akışına gidebilir.
+	 *
+	 * @param array<string, mixed> $state License state (sub_id metadata'sı yenileme URL'ine geçirilir).
+	 * @return void
+	 */
+	private function render_not_activated_banner( array $state = array() ) {
+		$accent       = '#d63638';
+		$bg           = '#fff0f0';
+		$style        = sprintf(
+			'padding:20px 24px;border-left-width:6px;border-left-color:%s;background:%s;margin:20px 0;',
+			$accent,
+			$bg
+		);
+		$purchase_url = $this->build_purchase_url( $state );
+		$email_masked = isset( $state['email_masked'] ) ? (string) $state['email_masked'] : '';
+		?>
+		<div class="notice notice-error hezarfen-pro-license-banner" style="<?php echo esc_attr( $style ); ?>">
+			<p style="font-size:14px;margin-top:0;">
+				<?php
+				esc_html_e(
+					'Hezarfen Pro lisansınız aktif değil. Güncellemeler, güvenlik güncellemeleri ve destek bu siteye gelmiyor.',
+					'hezarfen-for-woocommerce'
+				);
+				?>
+			</p>
+
+			<?php if ( '' !== $email_masked ) : ?>
+			<p style="margin-top:10px;font-size:13px;">
+				<?php
+				printf(
+					/* translators: %s: maskelenmiş e-posta adresi */
+					esc_html__( 'Bu lisans %s hesabına kayıtlı. Yenileme yapacaksanız bu hesapla oturum açmanız gerekecek.', 'hezarfen-for-woocommerce' ),
+					'<code>' . esc_html( $email_masked ) . '</code>'
+				);
+				?>
+			</p>
+			<?php endif; ?>
+
+			<p class="description" style="margin-top:8px;">
+				<?php
+				esc_html_e(
+					'Geçerli bir API anahtarınız varsa aşağıdaki "API Anahtarı" alanına yapıştırıp kaydedin. Aboneliğiniz dolduysa yenileyerek yeni bir anahtar alabilirsiniz.',
+					'hezarfen-for-woocommerce'
+				);
+				?>
+			</p>
+
+			<p style="margin-top:14px;">
+				<a href="<?php echo esc_url( $purchase_url ); ?>" target="_blank" rel="noopener" class="button button-primary button-hero">
+					<?php esc_html_e( 'Lisansı Yenile →', 'hezarfen-for-woocommerce' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * License info card'ını admin_footer'da gizli havuza yazar, sonra JS ile
+	 * aktivasyon formunun hemen üstüne (title ve nav-tab sonrası) enjekte eder.
+	 * Lisans aktif olduğu sürece (ok / expiring_soon) görünür.
+	 *
+	 * @return void
+	 */
+	public function inject_license_card_into_tab() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+		if ( ! $this->is_pro_license_screen() ) {
+			return;
+		}
+
+		$state = $this->monitor->get_license_state();
+		if ( ! in_array( $state['status'], array( 'ok', 'expiring_soon' ), true ) ) {
+			return;
+		}
+
+		ob_start();
+		$this->render_active_license_card( $state );
+		$card_html = ob_get_clean();
+		?>
+		<div id="hezarfen-pro-license-card-pool" style="display:none;"><?php echo $card_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — already escaped in render_active_license_card ?></div>
+		<script type="text/javascript">
+		(function(){
+			var pool = document.getElementById('hezarfen-pro-license-card-pool');
+			if ( ! pool ) { return; }
+			// Spesifik olarak kartı bul (style tag gibi diğer elementler pool'da kalabilir)
+			var card = pool.querySelector('.hezarfen-pro-license-info');
+			if ( ! card ) { return; }
+			var wrap = document.querySelector('.wrap');
+			if ( ! wrap ) { return; }
+
+			// Aktivasyon tab'ın formunu bul; onun hemen üstüne ekle
+			var form = wrap.querySelector('form[action*="options.php"]');
+			if ( form && form.parentNode ) {
+				form.parentNode.insertBefore( card, form );
+				return;
+			}
+
+			// Fallback: nav-tab-wrapper varsa ondan sonra
+			var navTab = wrap.querySelector('.nav-tab-wrapper');
+			if ( navTab && navTab.parentNode ) {
+				navTab.parentNode.insertBefore( card, navTab.nextSibling );
+				return;
+			}
+
+			// Son çare: h1 sonrası
+			var h1 = wrap.querySelector('h1');
+			if ( h1 && h1.parentNode ) {
+				h1.parentNode.insertBefore( card, h1.nextSibling );
+			}
+		})();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Renders the compact license info card — white background, single-row layout.
+	 *
+	 * @param array<string, mixed> $state License state.
+	 * @return void
+	 */
+	private function render_active_license_card( array $state ) {
+		$expires_ts   = (int) $state['support_expires_ts'];
+		$days_left    = max( 0, (int) $state['days_left'] );
+		$expires_date = wp_date( 'j F Y', $expires_ts );
+		$email_masked = (string) ( $state['email_masked'] ?? '' );
+		$sub_id       = (int) ( $state['sub_id'] ?? 0 );
+		$order_id     = (int) ( $state['order_id'] ?? 0 );
+
+		// Bitime yakın değilse (ok) yeşil; yakında bitiyorsa (expiring_soon) beyaz (banner zaten uyarıyor)
+		$is_ok  = 'ok' === $state['status'];
+		$bg     = $is_ok ? '#f0faf0' : '#fff';
+		$border = $is_ok ? '#46b450' : '#dcdcde';
+		?>
+		<style>
+			.hezarfen-license-tooltip {
+				position: relative;
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				width: 18px;
+				height: 18px;
+				border-radius: 50%;
+				background: #dcdcde;
+				color: #50575e;
+				font-size: 12px;
+				font-weight: 700;
+				cursor: help;
+				font-family: serif;
+				font-style: italic;
+			}
+			.hezarfen-license-tooltip::after {
+				content: attr(data-tooltip);
+				position: absolute;
+				bottom: calc(100% + 8px);
+				left: 50%;
+				transform: translateX(-50%);
+				background: #1d2327;
+				color: #fff;
+				padding: 6px 10px;
+				border-radius: 4px;
+				white-space: nowrap;
+				font-size: 12px;
+				font-style: normal;
+				font-weight: normal;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+				opacity: 0;
+				pointer-events: none;
+				transition: opacity 0.12s ease-in;
+				z-index: 999;
+			}
+			.hezarfen-license-tooltip::before {
+				content: '';
+				position: absolute;
+				bottom: calc(100% + 3px);
+				left: 50%;
+				transform: translateX(-50%);
+				border: 4px solid transparent;
+				border-top-color: #1d2327;
+				opacity: 0;
+				pointer-events: none;
+				transition: opacity 0.12s ease-in;
+			}
+			.hezarfen-license-tooltip:hover::after,
+			.hezarfen-license-tooltip:hover::before {
+				opacity: 1;
+			}
+		</style>
+		<div class="hezarfen-pro-license-info" style="padding:18px 22px;background:<?php echo esc_attr( $bg ); ?>;border:1px solid <?php echo esc_attr( $border ); ?>;border-radius:6px;margin:20px 0;">
+			<?php if ( '' !== $email_masked ) : ?>
+			<div style="margin-bottom:14px;">
+				<div style="font-size:11px;color:#646970;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;font-weight:600;">
+					<?php esc_html_e( 'Lisans sahibi', 'hezarfen-for-woocommerce' ); ?>
+				</div>
+				<div style="font-size:14px;display:flex;align-items:center;gap:6px;">
+					<code style="background:#f6f7f7;padding:3px 8px;border-radius:3px;"><?php echo esc_html( $email_masked ); ?></code>
+					<?php if ( $sub_id > 0 || $order_id > 0 ) : ?>
+						<?php
+						$tooltip_parts = array();
+						if ( $order_id > 0 ) {
+							$tooltip_parts[] = sprintf( __( 'Sipariş #%d', 'hezarfen-for-woocommerce' ), $order_id );
+						}
+						if ( $sub_id > 0 ) {
+							$tooltip_parts[] = sprintf( __( 'Abonelik #%d', 'hezarfen-for-woocommerce' ), $sub_id );
+						}
+						$tooltip = implode( ' · ', $tooltip_parts );
+						?>
+						<span class="hezarfen-license-tooltip" data-tooltip="<?php echo esc_attr( $tooltip ); ?>">i</span>
+					<?php endif; ?>
+				</div>
+			</div>
+			<?php endif; ?>
+
+			<div>
+				<div style="font-size:11px;color:#646970;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;font-weight:600;">
+					<?php esc_html_e( 'Destek süresi bitişi', 'hezarfen-for-woocommerce' ); ?>
+				</div>
+				<div style="font-size:14px;">
+					<strong><?php echo esc_html( $expires_date ); ?></strong>
+					<span style="color:#646970;margin-left:6px;">
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: %d: remaining days */
+								_n( '%d gün kaldı', '%d gün kaldı', $days_left, 'hezarfen-for-woocommerce' ),
+								$days_left
+							)
+						);
+						?>
+					</span>
+				</div>
+			</div>
+
+			<div style="margin-top:16px;">
+				<a href="<?php echo esc_url( $this->get_refresh_url() ); ?>"
+				   class="button button-small"
+				   title="<?php esc_attr_e( 'Lisans bilgilerini sunucudan yeniden çek', 'hezarfen-for-woocommerce' ); ?>">
+					<?php esc_html_e( '↻ Lisans Bilgilerini Tazele', 'hezarfen-for-woocommerce' ); ?>
+				</a>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Builds the checkout URL with renewal GET parameters (domain, license key, subscription id)
+	 * so the intense.com.tr side can auto-prefill and track the renewal.
+	 *
+	 * @param array<string, mixed> $state License state.
+	 * @return string
+	 */
+	private function build_purchase_url( array $state ) {
+		$args = array(
+			'renew_domain'              => (string) wp_parse_url( home_url(), PHP_URL_HOST ),
+			'renew_license_key'         => $this->monitor->get_api_key(),
+			'renew_old_subscription_id' => (int) ( $state['sub_id'] ?? 0 ),
+		);
+		$args = array_filter( $args, static function ( $v ) { return '' !== $v && 0 !== $v; } );
+		return add_query_arg( $args, $this->get_purchase_base_url() );
+	}
+
+	/**
+	 * Purchase URL'inin base'i. API_BASE override aktifse aynı host'u kullanır
+	 * ki local end-to-end testte renewal butonu intense.local'e gitsin.
+	 *
+	 * @return string
+	 */
+	private function get_purchase_base_url() {
+		if ( Pro_License_Monitor::is_api_base_overridden() ) {
+			return Pro_License_Monitor::get_api_base() . 'odeme/?add-to-cart-multiple=18509,241';
+		}
+		return self::PURCHASE_URL;
+	}
+
+	/**
+	 * Builds the wp-admin URL of the Pro license settings screen.
+	 *
+	 * @return string
+	 */
+	private function get_license_page_url() {
+		return admin_url( 'admin.php?page=' . self::PRO_LICENSE_SCREEN_KEY );
+	}
+
+	/**
+	 * "Yenile" butonundan gelen isteği yakalar: cache'i temizler, taze veri çeker,
+	 * sonra redirect eder ve başarı bildirimi gösterir.
+	 *
+	 * @return void
+	 */
+	public function handle_refresh_request() {
+		if ( empty( $_GET['hezarfen_pro_refresh'] ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+		check_admin_referer( self::REFRESH_NONCE );
+
+		$this->monitor->force_refresh();
+
+		$redirect = add_query_arg(
+			array( 'hezarfen_pro_refreshed' => 1 ),
+			$this->get_license_page_url()
+		);
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
+	 * Yenile sonrası success notice (admin_notices hook'una bağlı — sayfa üstünde
+	 * standart WP admin notice bölümünde gösterilir, kart akışını etkilemez).
+	 *
+	 * @return void
+	 */
+	public function render_refresh_notice() {
+		if ( empty( $_GET['hezarfen_pro_refreshed'] ) ) {
+			return;
+		}
+		if ( ! $this->is_pro_license_screen() ) {
+			return;
+		}
+		echo '<div class="notice notice-success is-dismissible"><p>'
+			. esc_html__( 'Lisans bilgileri yenilendi.', 'hezarfen-for-woocommerce' )
+			. '</p></div>';
+	}
+
+	/**
+	 * "Yenile" butonu URL'si (nonce'lı).
+	 *
+	 * @return string
+	 */
+	private function get_refresh_url() {
+		return wp_nonce_url(
+			add_query_arg( 'hezarfen_pro_refresh', '1', $this->get_license_page_url() ),
+			self::REFRESH_NONCE
+		);
+	}
+
+	/**
+	 * Renders the plugins list row-under bar for Hezarfen Pro.
+	 *
+	 * @param string               $plugin_file Plugin file path (unused, signature requirement).
+	 * @param array<string, mixed> $plugin_data Plugin data (unused).
+	 * @param string               $status      Status (unused).
+	 * @return void
+	 */
+	public function render_plugin_row_notice( $plugin_file, $plugin_data, $status ) {
+		unset( $plugin_file, $plugin_data, $status );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		$state = $this->monitor->get_license_state();
+		if ( ! in_array( $state['status'], array( 'expiring_soon', 'expired', 'not_activated' ), true ) ) {
+			return;
+		}
+
+		$is_expired = in_array( $state['status'], array( 'expired', 'not_activated' ), true );
+		$class      = $is_expired ? 'notice-error' : 'notice-warning';
+		$style      = $is_expired
+			? ''
+			: 'border-left-color:#d54e21;background:#fff4e5;';
+
+		$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
+		$colspan       = $wp_list_table ? (int) $wp_list_table->get_column_count() : 4;
+		?>
+		<tr class="plugin-update-tr active hezarfen-pro-license-row">
+			<td colspan="<?php echo (int) $colspan; ?>" class="plugin-update colspanchange">
+				<div class="update-message notice inline <?php echo esc_attr( $class ); ?> notice-alt" style="<?php echo esc_attr( $style ); ?>">
+					<p><?php echo wp_kses( $this->get_message_html( $state, 'row' ), $this->allowed_html() ); ?></p>
+				</div>
+			</td>
+		</tr>
+		<?php
+	}
+
+	/**
+	 * AJAX handler for dismissing the notice.
+	 *
+	 * @return void
+	 */
+	public function handle_dismiss() {
+		check_ajax_referer( self::NONCE_ACTION, 'nonce' );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( null, 403 );
+		}
+
+		$ts = isset( $_POST['support_expires_ts'] ) ? (int) $_POST['support_expires_ts'] : 0;
+		if ( $ts <= 0 ) {
+			wp_send_json_error( null, 400 );
+		}
+
+		update_user_meta( get_current_user_id(), self::USER_META_DISMISSED, $ts );
+		wp_send_json_success();
+	}
+
+	/**
+	 * Prints a dismissible (or non-dismissible) top-of-screen notice with inline dismiss JS.
+	 *
+	 * @param array<string, mixed> $state License state.
+	 * @return void
+	 */
+	private function print_standard_notice( array $state ) {
+		$is_expired   = 'expired' === $state['status'];
+		$class        = $is_expired ? 'notice-error' : 'notice-warning';
+		$dismissible  = $is_expired ? '' : 'is-dismissible';
+		$ts           = (int) $state['support_expires_ts'];
+		$nonce        = wp_create_nonce( self::NONCE_ACTION );
+		$style        = $is_expired
+			? 'border-left-width:6px;'
+			: 'border-left-color:#d54e21;border-left-width:6px;background:#fff4e5;';
+		?>
+		<div class="notice <?php echo esc_attr( trim( $class . ' ' . $dismissible ) ); ?> hezarfen-pro-license-notice" data-support-expires="<?php echo esc_attr( (string) $ts ); ?>" style="<?php echo esc_attr( $style ); ?>">
+			<p><?php echo wp_kses( $this->get_message_html( $state, 'admin_notice' ), $this->allowed_html() ); ?></p>
+		</div>
+		<?php if ( ! $is_expired ) : ?>
+		<script type="text/javascript">
+		(function($){
+			$(document).on('click', '.hezarfen-pro-license-notice .notice-dismiss', function(){
+				var ts = $(this).closest('.hezarfen-pro-license-notice').data('support-expires');
+				$.post(ajaxurl, {
+					action: '<?php echo esc_js( self::AJAX_ACTION_DISMISS ); ?>',
+					nonce: '<?php echo esc_js( $nonce ); ?>',
+					support_expires_ts: ts
+				});
+			});
+		})(jQuery);
+		</script>
+			<?php
+		endif;
+	}
+
+	/**
+	 * Builds the message HTML per variant.
+	 *
+	 * @param array<string, mixed> $state   License state.
+	 * @param string               $variant One of: admin_notice | banner | row.
+	 * @return string
+	 */
+	private function get_message_html( array $state, $variant ) {
+		$days         = max( 0, (int) $state['days_left'] );
+		$expires_date = esc_html( wp_date( 'j F Y', (int) $state['support_expires_ts'] ) );
+		$link         = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( $this->get_license_page_url() ),
+			esc_html__( 'Lisansı Yönet', 'hezarfen-for-woocommerce' )
+		);
+
+		if ( 'not_activated' === $state['status'] ) {
+			if ( 'row' === $variant ) {
+				return sprintf(
+					/* translators: 1: link HTML. */
+					__( '<strong>Hezarfen Pro:</strong> Lisansınız aktif değil — güncellemeler, güvenlik güncellemeleri ve destek aktif değil. %1$s', 'hezarfen-for-woocommerce' ),
+					$link
+				);
+			}
+			return sprintf(
+				/* translators: 1: link HTML. */
+				__( '<strong>Hezarfen Pro</strong> lisansınız aktif değil. Güncellemeler, güvenlik güncellemeleri ve destek bu siteye gelmiyor. %1$s', 'hezarfen-for-woocommerce' ),
+				$link
+			);
+		}
+
+		if ( 'expired' === $state['status'] ) {
+			if ( 'row' === $variant ) {
+				return sprintf(
+					/* translators: 1: link HTML. */
+					__( '<strong>Hezarfen Pro:</strong> Destek ve güncelleme süreniz doldu — güvenlik yamaları ve yeni özellikler artık gelmiyor. %1$s', 'hezarfen-for-woocommerce' ),
+					$link
+				);
+			}
+			return sprintf(
+				/* translators: 1: link HTML. */
+				__( '<strong>Hezarfen Pro</strong> destek ve güncelleme süreniz <strong>doldu</strong>. Güvenlik yamaları, WooCommerce/WordPress uyumluluk güncellemeleri ve yeni kargo entegrasyonları artık bu siteye gelmiyor. Mevcut aboneliğinizi yeniden ödeyebilir veya yeni bir sipariş oluşturabilirsiniz. %1$s', 'hezarfen-for-woocommerce' ),
+				$link
+			);
+		}
+
+		// expiring_soon
+		if ( 'row' === $variant ) {
+			return sprintf(
+				/* translators: 1: expiry date, 2: remaining days, 3: link HTML. */
+				__( '<strong>Hezarfen Pro:</strong> Destek süreniz %1$s tarihinde sona eriyor (%2$d gün kaldı). Güvenlik yamaları ve yeni özellikler kesilecek. %3$s', 'hezarfen-for-woocommerce' ),
+				$expires_date,
+				$days,
+				$link
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: expiry date, 2: remaining days, 3: link HTML. */
+			__( '<strong>Hezarfen Pro</strong> destek ve güncelleme süreniz <strong>%1$s</strong> tarihinde sona eriyor (%2$d gün kaldı). Süre bittiğinde güvenlik yamaları, WooCommerce uyumluluk güncellemeleri ve yeni kargo entegrasyonları bu siteye gelmez. Kesintisiz kullanım için mevcut aboneliğinizi ödeyebilir veya yeni bir sipariş oluşturabilirsiniz. %3$s', 'hezarfen-for-woocommerce' ),
+			$expires_date,
+			$days,
+			$link
+		);
+	}
+
+	/**
+	 * Allowed HTML tags for wp_kses in notice messages.
+	 *
+	 * @return array<string, array<string, bool>>
+	 */
+	private function allowed_html() {
+		return array(
+			'strong' => array(),
+			'a'      => array(
+				'href'   => true,
+				'target' => true,
+				'rel'    => true,
+			),
+		);
+	}
+}

--- a/includes/class-hezarfen.php
+++ b/includes/class-hezarfen.php
@@ -67,6 +67,9 @@ class Hezarfen {
 
 		// Register roadmap voting AJAX action
 		add_action( 'wp_ajax_hezarfen_submit_roadmap_votes', array( $this, 'handle_roadmap_vote_submission_proxy' ) );
+
+		$pro_license_monitor = new Pro_License_Monitor();
+		new Pro_License_Notice( $pro_license_monitor );
 	}
 
 	/**


### PR DESCRIPTION
## Özet

Kapanan #140'taki lisans bitiş uyarısı çalışmasının güncel `develop` üzerine **çakışmasız** (sadece-ekleme, 1172 satır / 0 silme) yeniden uygulanmış hali.

- **`Pro_License_Monitor`** (data layer): günlük cron + `admin_init` ile intense.com.tr Pro abonelik status endpoint'ini çağırıp `support_expires_ts`'i cache'liyor. Pro lisans ekranına girildiğinde son sync 1 saatten eskiyse anında refresh ediyor (yenileme sonrası banner'ın hemen güncel görünmesi için).
- **`Pro_License_Notice`** (UI layer): 30 gün eşiğine girince üç yüzeyde uyarı — global `admin_notices`, Eklentiler listesinde Pro satırının altı, Pro lisans ayar ekranındaki sayfa içi banner. "Dismiss" per-user ve mevcut `support_expires_ts`'e bağlı; abonelik yenilendiğinde yeni timestamp uyarıyı otomatik geri getiriyor.
- `Autoload.php` + `class-hezarfen.php` boot sırasına iki sınıfın `require` ve instance'ı eklendi.

## Test planı

- [ ] Pro lisans verisi mevcutken admin paneline girip cron'un programlandığını doğrula (`wp cron event list | grep hezarfen_check_pro_license_expiry`)
- [ ] `hezarfen_pro_license_status_cache` opsiyonunu 25 gün sonra bitecek `support_expires_ts` ile elle güncelle, `admin_notices` / Plugins listesi / Pro lisans ekranında uyarının çıktığını doğrula
- [ ] Uyarıyı dismiss et; aynı kullanıcıda kaybolduğunu, başka admin kullanıcısında hâlâ göründüğünü doğrula
- [ ] Cache'deki `support_expires_ts`'i yeni değere güncelle; dismiss edilmiş kullanıcıda uyarının tekrar göründüğünü doğrula
- [ ] Pro lisans ekranını aç, 1 saatten eski sync varsa fresh fetch tetiklendiğini doğrula

🤖 Generated with [Claude Code](https://claude.com/claude-code)